### PR TITLE
Moving collection route to admin/content

### DIFF
--- a/islandora.links.menu.yml
+++ b/islandora.links.menu.yml
@@ -1,11 +1,3 @@
-# Fedora resource menu items definition
-entity.fedora_resource.collection:
-  title: 'Fedora resource list'
-  route_name: entity.fedora_resource.collection
-  description: 'List Fedora resource entities'
-  parent: system.admin_structure
-  weight: 100
-
 # Fedora resource type menu items definition
 entity.fedora_resource_type.collection:
   title: 'Fedora resource type list'

--- a/islandora.links.task.yml
+++ b/islandora.links.task.yml
@@ -14,3 +14,8 @@ entity.fedora_resource.delete_form:
   base_route:  entity.fedora_resource.canonical
   title: Delete
   weight: 10
+
+entity.fedora_resource.collection:
+  route_name: entity.fedora_resource.collection
+  base_route: system.admin_content
+  title: 'Fedora Resources'

--- a/src/Entity/FedoraResource.php
+++ b/src/Entity/FedoraResource.php
@@ -57,7 +57,7 @@ use Drupal\user\UserInterface;
  *     "add-form" = "/fedora_resource/add/{fedora_resource_type}",
  *     "edit-form" = "/fedora_resource/{fedora_resource}/edit",
  *     "delete-form" = "/fedora_resource/{fedora_resource}/delete",
- *     "collection" = "/admin/structure/fedora_resource",
+ *     "collection" = "/admin/content/fedora_resource",
  *   },
  *   bundle_entity_type = "fedora_resource_type",
  *   field_ui_base_route = "entity.fedora_resource_type.edit_form"
@@ -293,7 +293,7 @@ class FedoraResource extends ContentEntityBase implements FedoraResourceInterfac
       ))
       ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', TRUE);
-      
+
       $fields['fedora_has_parent'] = BaseFieldDefinition::create('entity_reference')
         ->setLabel(t('Fedora has Parent'))
         ->setDescription(t('Parent Fedora Resource.'))


### PR DESCRIPTION
Addresses https://github.com/Islandora-CLAW/CLAW/issues/418.

To test this pull:
- After pulling down the code, do a `drupal cache:rebuild all`
- Go to `admin/content`, you should see a tab for 'Fedora Resources'
![screenshot from 2016-11-14 13-08-51](https://cloud.githubusercontent.com/assets/20773151/20274644/bbe2898e-aa6b-11e6-8278-62ffad5e5b61.png)
- Click on the tab, and you should see a listing of the FedoraResource entities on your site, with operations to manage them.
![screenshot from 2016-11-14 13-09-21](https://cloud.githubusercontent.com/assets/20773151/20274651/c1b0f01c-aa6b-11e6-9e9c-414c321a678e.png)

