### PR TITLE
Generated tables now

### DIFF
--- a/src/Entity/FedoraResource.php
+++ b/src/Entity/FedoraResource.php
@@ -39,9 +39,11 @@ use Drupal\user\UserInterface;
  *   data_table = "fedora_resource_field_data",
  *   revision_table = "fedora_resource_revision",
  *   revision_data_table = "fedora_resource_field_data_revision",
+ *   translatable = TRUE,
  *   admin_permission = "administer fedora resource entities",
  *   entity_keys = {
  *     "id" = "id",
+ *     "revision" = "vid",
  *     "bundle" = "type",
  *     "label" = "name",
  *     "uuid" = "uuid",
@@ -258,6 +260,11 @@ class FedoraResource extends ContentEntityBase implements FedoraResourceInterfac
       ->setLabel(t('ID'))
       ->setDescription(t('The ID of the Fedora resource entity.'))
       ->setReadOnly(TRUE);
+    $fields['vid'] = BaseFieldDefinition::create('integer')
+      ->setLabel(t('Revision ID'))
+      ->setDescription(t('The Fedora resource revision ID.'))
+      ->setReadOnly(TRUE)
+      ->setSetting('unsigned', TRUE);
     $fields['type'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('Type'))
       ->setDescription(t('The Fedora resource type/bundle.'))
@@ -293,7 +300,7 @@ class FedoraResource extends ContentEntityBase implements FedoraResourceInterfac
       ))
       ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', TRUE);
-      
+
       $fields['fedora_has_parent'] = BaseFieldDefinition::create('entity_reference')
         ->setLabel(t('Fedora has Parent'))
         ->setDescription(t('Parent Fedora Resource.'))


### PR DESCRIPTION
Addresses https://github.com/Islandora-CLAW/CLAW/issues/419.  See issue for testing instructions.

Turns out ContentEntityBase does a lookup based on the annotations to determine if it should make tables upon module install for an entity.  The revision tables require a 'revision' entity_key get made.  Adding 'translatable' ensures the data tables get made as well.

# Uninstall the islandora module before you pull down this code!!!

If you pull down the code with git, you're defining a revision entity_key that does not exist yet.  Your database will go kaboom.  I've done it twice today because of this.  Just a heads up.