### PR TITLE
Add new configuration settings

### DIFF
--- a/config/install/islandora.settings.yml
+++ b/config/install/islandora.settings.yml
@@ -1,2 +1,4 @@
 broker_url: 'http://localhost:61613'
 triplestore_index_queue: '/islandora/triplestore/index'
+fedora_rest_endpoint: 'http://localhost:8080/fcrepo/rest'
+fedora_indexing_queue: 'islandora/indexing/fedora'

--- a/src/Form/IslandoraSettingsForm.php
+++ b/src/Form/IslandoraSettingsForm.php
@@ -17,6 +17,8 @@ class IslandoraSettingsForm extends ConfigFormBase {
   const CONFIG_NAME = 'islandora.settings';
   const BROKER_URL = 'broker_url';
   const TRIPLESTORE_INDEX_QUEUE = 'triplestore_index_queue';
+  const FEDORA_REST_ENDPOINT = 'fedora_rest_endpoint';
+  const FEDORA_INDEXING_QUEUE = 'fedora_indexing_queue';
 
   /**
    * {@inheritdoc}
@@ -52,6 +54,20 @@ class IslandoraSettingsForm extends ConfigFormBase {
       '#default_value' => $config->get(self::TRIPLESTORE_INDEX_QUEUE),
     );
 
+    $form[self::FEDORA_REST_ENDPOINT] = array(
+      '#type' => 'textfield',
+      '#title' => $this->t('Fedora REST Endpoint'),
+      '#description' => $this->t('The URL for your Fedora instance.'),
+      '#default_value' => $config->get(self::FEDORA_REST_ENDPOINT),
+    );
+
+    $form[self::FEDORA_INDEXING_QUEUE] = array(
+      '#type' => 'textfield',
+      '#title' => $this->t('Fedora Indexing Queue Name'),
+      '#description' => $this->t('Name of the queue where Drupal will publish updates to have "indexed" to Fedora'),
+      '#default_value' => $config->get(self::FEDORA_INDEXING_QUEUE),
+    );
+
     return parent::buildForm($form, $form_state);
   }
 
@@ -64,6 +80,8 @@ class IslandoraSettingsForm extends ConfigFormBase {
     $config
       ->set(self::BROKER_URL, $form_state->getValue(self::BROKER_URL))
       ->set(self::TRIPLESTORE_INDEX_QUEUE, $form_state->getValue(self::TRIPLESTORE_INDEX_QUEUE))
+      ->set(self::FEDORA_REST_ENDPOINT, $form_state->getValue(self::FEDORA_REST_ENDPOINT))
+      ->set(self::FEDORA_INDEXING_QUEUE, $form_state->getValue(self::FEDORA_INDEXING_QUEUE))
       ->save();
 
     parent::submitForm($form, $form_state);


### PR DESCRIPTION
Resolves https://github.com/Islandora-CLAW/CLAW/issues/431

### What does this change
Adds two new fields to the Islandora settings `http://localhost:8000/admin/config/islandora/core`
1. Fedora REST Endpoint
2. Fedora Indexing Queue Name

It also adds default values to the `config/install/islandora.settings.yml` file.

### How to test
1. Install this PR in your Drupal 8.2.2 installation (if you already have the Islandora module installed, Uninstall it before you checkout this PR branch. Then reinstall the module.)
2. Browse to `http://<your host and port>/admin/config/islandora/core` 
3. Ensure you see **4** fields. 
4. Ensure they have default values
5. Ensure that you can edit and save those values and they persist if you leave the page and return.