### PR TITLE
Correctly get parent

### DIFF
--- a/islandora/src/Entity/FedoraResource.php
+++ b/islandora/src/Entity/FedoraResource.php
@@ -267,7 +267,7 @@ class FedoraResource extends ContentEntityBase implements FedoraResourceInterfac
    */
   public static function getFedoraRoot() {
     // Just stub code, we need to figure out what "root is" in this context.
-    return array('root');
+    return NULL;
   }
 
   /**
@@ -325,7 +325,7 @@ class FedoraResource extends ContentEntityBase implements FedoraResourceInterfac
       ->setRevisionable(TRUE)
       ->setSetting('target_type', 'fedora_resource')
       ->setSetting('handler', 'default')
-      ->setDefaultValue(NULL)
+      ->setDefaultValue('Drupal\islandora\Entity\FedoraResource::getFedoraRoot')
       ->setTranslatable(TRUE)
       ->setDisplayOptions('view', array(
         'label' => 'hidden',

--- a/islandora/src/Entity/FedoraResource.php
+++ b/islandora/src/Entity/FedoraResource.php
@@ -223,21 +223,30 @@ class FedoraResource extends ContentEntityBase implements FedoraResourceInterfac
    * {@inheritdoc}
    */
   public function hasParent() {
-    return ($this->get('fedora_has_parent') !== NULL);
+    return ($this->get('fedora_has_parent')->first() !== NULL);
   }
 
   /**
    * {@inheritdoc}
    */
   public function getParent() {
-    return $this->get('fedora_has_parent')->getEntity();
+    return $this->get('fedora_has_parent')
+      ->first()
+      ->get('entity')
+      ->getTarget()
+      ->getValue();
   }
 
   /**
    * {@inheritdoc}
    */
   public function getParentId() {
-    return $this->get('fedora_has_parent')->getEntity()->id();
+    return $this->get('fedora_has_parent')
+      ->first()
+      ->get('entity')
+      ->getTarget()
+      ->getValue()
+      ->id();
   }
 
   /**
@@ -316,7 +325,7 @@ class FedoraResource extends ContentEntityBase implements FedoraResourceInterfac
       ->setRevisionable(TRUE)
       ->setSetting('target_type', 'fedora_resource')
       ->setSetting('handler', 'default')
-      ->setDefaultValueCallback('Drupal\islandora\Entity\FedoraResource::getFedoraRoot')
+      ->setDefaultValue(NULL)
       ->setTranslatable(TRUE)
       ->setDisplayOptions('view', array(
         'label' => 'hidden',

--- a/islandora/src/Entity/FedoraResource.php
+++ b/islandora/src/Entity/FedoraResource.php
@@ -325,7 +325,7 @@ class FedoraResource extends ContentEntityBase implements FedoraResourceInterfac
       ->setRevisionable(TRUE)
       ->setSetting('target_type', 'fedora_resource')
       ->setSetting('handler', 'default')
-      ->setDefaultValue('Drupal\islandora\Entity\FedoraResource::getFedoraRoot')
+      ->setDefaultValueCallback('Drupal\islandora\Entity\FedoraResource::getFedoraRoot')
       ->setTranslatable(TRUE)
       ->setDisplayOptions('view', array(
         'label' => 'hidden',


### PR DESCRIPTION
Resolves https://github.com/Islandora-CLAW/CLAW/issues/443

How to test:

First create a Fedora Resource (Content -> Fedora Resource -> Add Fedora Resource) 
**DON'T** set a parent.
Save the new Fedora Resource.

Create a second Fedora Resource and set this parent as the first Fedora Resource you created.
Save the new Fedora Resource.

View the Fedora Resource List (Content -> Fedora Resource), each Fedora Resource lists itself as it's own parent.
ie.
![issue-443-1](https://cloud.githubusercontent.com/assets/2857697/20873291/ae0784e4-ba6b-11e6-8379-81e9836194d1.jpg)


Checkout this PR, perform cache rebuild (`drupal cache:rebuild all` at drupal root folder), refresh the Fedora Resource List. The parents should be correct.
![issue-443-2](https://cloud.githubusercontent.com/assets/2857697/20873296/b667b5f0-ba6b-11e6-8ee2-45e4a814914b.jpg)
