### PR TITLE
Add default RDF mapping for NonRdfSource 

### DIFF
--- a/islandora/config/install/rdf.mapping.fedora_resource_type.non_rdf_source.yml
+++ b/islandora/config/install/rdf.mapping.fedora_resource_type.non_rdf_source.yml
@@ -10,8 +10,7 @@ targetEntityType: fedora_resource
 bundle: non_rdf_source
 types:
   - 'schema:Thing'
-  - 'ldp:RDFSource'
-  - 'ldp:Container'
+  - 'ldp:NonRDFSource'
 fieldMappings:
   title:
     properties:

--- a/islandora/config/install/rdf.mapping.fedora_resource_type.non_rdf_source.yml
+++ b/islandora/config/install/rdf.mapping.fedora_resource_type.non_rdf_source.yml
@@ -1,0 +1,44 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - islandora.fedora_resource_type.non_rdf_source
+  module:
+    - islandora
+id: fedora_resource_type._non_rdf_source
+targetEntityType: fedora_resource
+bundle: non_rdf_source
+types:
+  - 'schema:Thing'
+  - 'ldp:RDFSource'
+  - 'ldp:Container'
+fieldMappings:
+  title:
+    properties:
+      - 'dc11:title'
+      - 'rdf:label'
+  created:
+    properties:
+      - 'schema:dateCreated'
+    datatype_callback:
+      callable: 'Drupal\rdf\CommonDataConverter::dateIso8601Value'
+  changed:
+    properties:
+      - 'schema:dateModified'
+    datatype_callback:
+      callable: 'Drupal\rdf\CommonDataConverter::dateIso8601Value'
+  rdf_type:
+    properties:
+      - 'rdf:type'
+  uid:
+    properties:
+      - 'schema:author'
+    mapping_type: rel
+  fedora_has_parent:
+    properties:
+      - 'fedora:hasParent'
+    mapping_type: rel
+  ldp_contains:
+    properties:
+      - 'ldp:contains'
+    mapping_type: rel

--- a/islandora/config/install/rdf.mapping.fedora_resource_type.non_rdf_source.yml
+++ b/islandora/config/install/rdf.mapping.fedora_resource_type.non_rdf_source.yml
@@ -5,7 +5,7 @@ dependencies:
     - islandora.fedora_resource_type.non_rdf_source
   module:
     - islandora
-id: fedora_resource_type._non_rdf_source
+id: fedora_resource_type.non_rdf_source
 targetEntityType: fedora_resource
 bundle: non_rdf_source
 types:


### PR DESCRIPTION
Resolves https://github.com/Islandora-CLAW/CLAW/issues/444

How to test:

First create a Fedora Resource of type **Non RDF Source** (Content -> Fedora Resource -> Add Fedora Resource)
Save the new Fedora Resource.

View the JSON-LD serialization by adding `?_format=jsonld` to the URL. You'll only see `@id` and `@type`

ie.
```
{"@graph":[{"@id":"http:\/\/localhost:8000\/fedora_resource\/6?_format=jsonld","@type":["http:\/\/schema.org\/Thing","http:\/\/www.w3.org\/ns\/ldp#RDFSource","http:\/\/www.w3.org\/ns\/ldp#Container"]}
```

Next checkout this PR branch. Install the included in the file `islandora/config/install/rdf.mapping.fedora_resource_type.non_rdf_source.yml` as a single item configuration and reload the the JSON-LD serialization of the Fedora Resource and see lots more information.
```
{"@graph":[{"@id":"http:\/\/localhost:8000\/fedora_resource\/6?_format=jsonld","@type":["http:\/\/schema.org\/Thing","http:\/\/www.w3.org\/ns\/ldp#RDFSource","http:\/\/www.w3.org\/ns\/ldp#Container"],"http:\/\/fedora.info\/definitions\/v4\/repository#hasParent":[{"@id":"http:\/\/localhost:8000\/fedora_resource\/4?_format=jsonld"}],"http:\/\/schema.org\/dateCreated":[{"@value":"2016-12-05T03:52:27+00:00"}],"http:\/\/schema.org\/dateModified":[{"@value":"2016-12-05T03:52:27+00:00"}]},{"@id":"http:\/\/localhost:8000\/fedora_resource\/4?_format=jsonld","@type":["http:\/\/schema.org\/Thing","http:\/\/www.w3.org\/ns\/ldp#RDFSource","http:\/\/www.w3.org\/ns\/ldp#Container"]}]}
```