### PR TITLE
Issue 429

### DIFF
--- a/islandora/config/install/rdf.mapping.fedora_resource_type.rdf_source.yml
+++ b/islandora/config/install/rdf.mapping.fedora_resource_type.rdf_source.yml
@@ -30,6 +30,9 @@ fieldMappings:
   rdf_type:
     properties:
       - 'rdf:type'
+  vclock:
+    properties:
+      - 'islandora:vclock'
   uid:
     properties:
       - 'schema:author'

--- a/islandora/islandora.module
+++ b/islandora/islandora.module
@@ -80,5 +80,6 @@ function islandora_rdf_namespaces() {
     'owl' => 'http://www.w3.org/2002/07/owl#',
     'ore' => 'http://www.openarchives.org/ore/terms/',
     'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+    'islandora' => 'http://islandora.ca/CLAW/',
   );
 }

--- a/islandora/src/Entity/FedoraResource.php
+++ b/islandora/src/Entity/FedoraResource.php
@@ -124,6 +124,18 @@ class FedoraResource extends ContentEntityBase implements FedoraResourceInterfac
   /**
    * {@inheritdoc}
    */
+  public function preSave(EntityStorageInterface $storage) {
+    parent::preSave($storage);
+
+    // Increment the vclock.
+    if (!$this->isNew()) {
+      $this->set("vclock", $this->get("vclock")->value + 1);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function postSave(EntityStorageInterface $storage, $update = TRUE) {
     parent::postSave($storage, $update);
 
@@ -264,6 +276,13 @@ class FedoraResource extends ContentEntityBase implements FedoraResourceInterfac
   /**
    * {@inheritdoc}
    */
+  public function getVclock() {
+    return $this->get('vclock')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public static function baseFieldDefinitions(EntityTypeInterface $entity_type) {
     $fields['id'] = BaseFieldDefinition::create('integer')
       ->setLabel(t('ID'))
@@ -283,6 +302,11 @@ class FedoraResource extends ContentEntityBase implements FedoraResourceInterfac
       ->setLabel(t('UUID'))
       ->setDescription(t('The UUID of the Fedora resource entity.'))
       ->setReadOnly(TRUE);
+    $fields['vclock'] = BaseFieldDefinition::create('integer')
+      ->setLabel(t('Vector Clock'))
+      ->setDescription(t('Simple accumulator used for causality tracking'))
+      ->setDefaultValue(0)
+      ->setSetting('unsigned', TRUE);
 
     $fields['user_id'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('Authored by'))

--- a/islandora/src/FedoraResourceInterface.php
+++ b/islandora/src/FedoraResourceInterface.php
@@ -117,4 +117,12 @@ interface FedoraResourceInterface extends ContentEntityInterface, EntityChangedI
    */
   public function setParent(EntityTypeInterface $entity);
 
+  /**
+   * Gets the vector clock of this entity.
+   *
+   * @return in
+   *   The vector clock, used for determining causality.
+   */
+  public function getVclock();
+
 }

--- a/islandora/src/FedoraResourceInterface.php
+++ b/islandora/src/FedoraResourceInterface.php
@@ -120,7 +120,7 @@ interface FedoraResourceInterface extends ContentEntityInterface, EntityChangedI
   /**
    * Gets the vector clock of this entity.
    *
-   * @return in
+   * @return int
    *   The vector clock, used for determining causality.
    */
   public function getVclock();

--- a/islandora/tests/src/Kernel/EventGeneratorTest.php
+++ b/islandora/tests/src/Kernel/EventGeneratorTest.php
@@ -4,7 +4,6 @@ namespace Drupal\Tests\islandora\Kernel;
 
 use Drupal\islandora\Entity\FedoraResource;
 use Drupal\islandora\EventGenerator\EventGenerator;
-use Drupal\KernelTests\KernelTestBase;
 use Drupal\simpletest\UserCreationTrait;
 
 /**
@@ -12,7 +11,7 @@ use Drupal\simpletest\UserCreationTrait;
  *
  * @group islandora
  */
-class EventGeneratorTest extends KernelTestBase {
+class EventGeneratorTest extends IslandoraKernelTestBase {
 
   use UserCreationTrait {
     createUser as drupalCreateUser;
@@ -42,35 +41,8 @@ class EventGeneratorTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
-    'system',
-    'user',
-    'field',
-    'filter',
-    'block',
-    'node',
-    'path',
-    'text',
-    'options',
-    'inline_entity_form',
-    'serialization',
-    'rest',
-    'rdf',
-    'jsonld',
-    'islandora'
-  ];
-
-  /**
-   * {@inheritdoc}
-   */
   public function setUp() {
     parent::setUp();
-
-    // Bootstrap minimal Drupal environment to run the tests.
-    $this->installSchema('system', 'sequences');
-    $this->installEntitySchema('user');
-    $this->installConfig('filter');
-    $this->installEntitySchema('fedora_resource');
 
     // Create a test user.
     $this->user = $this->drupalCreateUser();

--- a/islandora/tests/src/Kernel/IslandoraKernelTestBase.php
+++ b/islandora/tests/src/Kernel/IslandoraKernelTestBase.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Drupal\Tests\islandora\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Abstract base class for Islandora kernel tests.
+ *
+ */
+abstract class IslandoraKernelTestBase extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'system',
+    'user',
+    'field',
+    'filter',
+    'block',
+    'node',
+    'path',
+    'text',
+    'options',
+    'inline_entity_form',
+    'serialization',
+    'rest',
+    'rdf',
+    'jsonld',
+    'islandora'
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    // Bootstrap minimal Drupal environment to run the tests.
+    $this->installSchema('system', 'sequences');
+    $this->installEntitySchema('user');
+    $this->installConfig('filter');
+    $this->installEntitySchema('fedora_resource');
+  }
+
+}
+

--- a/islandora/tests/src/Kernel/VectorClockTest.php
+++ b/islandora/tests/src/Kernel/VectorClockTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\Tests\islandora\Kernel;
+
+use Drupal\islandora\Entity\FedoraResource;
+use Drupal\simpletest\UserCreationTrait;
+
+/**
+ * Tests the basic behavior of a vector clock.
+ *
+ * @group islandora
+ */
+class VectorClockTest extends IslandoraKernelTestBase {
+
+  /**
+   * Fedora resource entity.
+   *
+   * @var \Drupal\islandora\FedoraResourceInterface
+   */
+  protected $entity;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    // Create a test entity.
+    $this->entity = FedoraResource::create([
+      "type" => "rdf_source",
+      "uid" => 1,
+      "name" => "Test Fixture",
+      "langcode" => "und",
+      "status" => 1,
+    ]); 
+    $this->entity->save();
+
+  }
+
+  /**
+   * Tests the basic behavior of the vector clock.
+   */
+  public function testVectorClock() {
+    // Check the vclock is set to 0 when a new entity is created.
+    $this->assertTrue($this->entity->getVclock() == 0, "Vector clock initialized to zero.");
+    
+    // Edit the entity.
+    $this->entity->setName("Edited Test Fixture")->save();
+
+    // Check the vclock is incremented when the entity is updated.
+    $this->assertTrue($this->entity->getVclock() == 1, "Vector clock incremented on update.");
+  }
+
+}

--- a/islandora_collection/config/install/rdf.mapping.fedora_resource_type.collection.yml
+++ b/islandora_collection/config/install/rdf.mapping.fedora_resource_type.collection.yml
@@ -40,6 +40,9 @@ fieldMappings:
   rdf_type:
     properties:
       - 'rdf:type'
+  vclock:
+    properties:
+      - 'islandora:vclock'
   uid:
     properties:
       - 'schema:author'


### PR DESCRIPTION
Resolves https://github.com/Islandora-CLAW/CLAW/issues/429

Provides a vclock base field and naive update strategy.  Also updates our rdf mappings with a dummy predicate and namespace until the ontology gets hashed out

### To Test
There's functional tests for this, but if you want to do it manually:
- Uninstall the module
- Pull down the code
- Re-install the module
- Create a RdfResource or Collection
- View it's Devel tab, you should have a vclock of 0
- Update the entity
- View it's Devel tab, you should have a vclock of 1
- Enable the fedora_resource endpoint through REST UI
- Retrieve a jsonld representation of your entity
- The vclock should appear as http://islandora.ca/CLAW/vclock