### PR TITLE
add fedora resource teaser config schema for issue #447

### DIFF
--- a/islandora/config/install/core.entity_view_mode.fedora_resource.teaser.yml
+++ b/islandora/config/install/core.entity_view_mode.fedora_resource.teaser.yml
@@ -1,0 +1,10 @@
+uuid: 0efc20d3-0bd6-4606-842f-b87548de1924
+langcode: en
+status: true
+dependencies:
+  module:
+    - islandora
+id: fedora_resource.teaser
+label: Teaser
+targetEntityType: fedora_resource
+cache: true


### PR DESCRIPTION
Addresses issue [Islandora-CLAW/CLAW#447](https://github.com/Islandora-CLAW/CLAW/issues/447), tested by exporting and importing again, and enabling view mode to Non-RDF source and RDF source.