### PR TITLE
Change how we setup travis to use composer to install all dependencies

### DIFF
--- a/.scripts/line_endings.sh
+++ b/.scripts/line_endings.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 RETURN=0
-FILES=`find -L $1 -name "*.info" -o -name "*.txt" -o -name "*.md"`
+FILES=`find -L $1 -name "*"`
 echo "Testing for files with DOS line endings..."
 for FILE in $FILES
 do

--- a/.scripts/php56.ini
+++ b/.scripts/php56.ini
@@ -1,0 +1,5 @@
+; there is an issue with php 5.6 that causes travis to fail
+; some info about it here:
+; https://bugs.php.net/bug.php?id=66763
+; https://www.drupal.org/node/2456025
+always_populate_raw_post_data = -1

--- a/.scripts/travis_setup.sh
+++ b/.scripts/travis_setup.sh
@@ -1,80 +1,43 @@
 #!/bin/bash
+echo "Setup database for Drupal"
 mysql -u root -e 'create database drupal;'
 mysql -u root -e "GRANT ALL PRIVILEGES ON drupal.* To 'drupal'@'localhost' IDENTIFIED BY 'drupal';"
 
-cd $HOME
-pear channel-discover pear.drush.org
-pear upgrade --force Console_GetoptPlus
-pear upgrade --force pear
-pear channel-discover pear.drush.org
+if [ $TRAVIS_PHP_VERSION = "5.6" ]; then
+  phpenv config-add $SCRIPT_DIR/php56.ini
+fi
 
-# Drush
-cd /tmp
-php -r "readfile('https://s3.amazonaws.com/files.drush.org/drush.phar');" > drush
-php drush core-status
-chmod +x drush
-sudo mv drush /opt
-sudo ln -s /opt/drush /usr/bin/drush
+echo "Install utilities needed for testing"
+mkdir /opt/utils
+cd /opt/utils
+composer require squizlabs/php_codesniffer
+composer require drupal/coder
+composer require sebastian/phpcpd
+sudo ln -s /opt/utils/vendor/bin/phpcs /usr/bin/phpcs
+sudo ln -s /opt/utils/vendor/bin/phpcpd /usr/bin/phpcpd
+phpenv rehash
+phpcs --config-set installed_paths /opt/utils/vendor/drupal/coder/coder_sniffer
 
+echo "Composer install drupal site"
+cd /opt
+git clone https://github.com/Islandora-CLAW/drupal-project.git drupal
+cd drupal
+composer install
+
+echo "Setup Drush"
+sudo ln -s /opt/drupal/vendor/bin/drush /usr/bin/drush
 phpenv rehash
 
-cd $HOME
-drush dl drupal-8.2.2 --drupal-project-rename=drupal
-cd $HOME/drupal
-drush si minimal --db-url=mysql://drupal:drupal@localhost/drupal --yes
+echo "Drush setup drupal site"
+cd web
+drush si --db-url=mysql://drupal:drupal@localhost/drupal --yes
 drush runserver --php-cgi=$HOME/.phpenv/shims/php-cgi localhost:8081 &>/tmp/drush_webserver.log &
 
-ln -s $ISLANDORA_DIR modules/islandora
-drush en -y rdf
-drush en -y responsive_image
-drush en -y syslog
-drush en -y serialization
-drush en -y basic_auth
-drush en -y rest
+echo "Enable simpletest module"
 drush en -y simpletest
 
-drush dl rdfui --dev
-drush en -y rdfui
-drush en -y rdf_builder
-
-drush dl restui
-drush en -y restui
-
-drush dl inline_entity_form
-drush en -y inline_entity_form
-
-drush dl media_entity
-drush en -y media_entity
-
-drush dl media_entity_image
-drush en -y media_entity_image
-
-drush dl search_api
-drush -y pm-uninstall search
-drush en -y search_api
-
-drush dl typed_data
-drush en -y typed_data 
-
-drush dl rules
-drush en -y rules 
-
-cd $HOME/drupal/modules
-git clone https://github.com/DiegoPino/claw-jsonld.git
-drush en -y jsonld
-
-drush en -y islandora
-
-drush cr
-
-# ACTIVEMQ
-cd $HOME 
+echo "Setup ActiveMQ"
+cd /opt
 wget "http://archive.apache.org/dist/activemq/5.14.3/apache-activemq-5.14.3-bin.tar.gz"
 tar -xzf apache-activemq-5.14.3-bin.tar.gz
-sudo sed -i 's|ACTIVEMQ_USER="activemq"|ACTIVEMQ_USER="travis"|' /etc/default/activemq
 apache-activemq-5.14.3/bin/activemq start
-
-# The shebang in this file is a bogeyman that is haunting the web test cases.
-rm /home/travis/.phpenv/rbenv.d/exec/hhvm-switcher.bash
-
-sleep 20

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,9 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - hhvm
+  - 7.1
 
 matrix:
-    allow_failures:
-        - php: hhvm
     fast_finish: true
 
 branches:
@@ -16,20 +14,20 @@ branches:
     - /^8.x/
 
 before_install:
-  - export ISLANDORA_DIR=$TRAVIS_BUILD_DIR
+  - export SCRIPT_DIR=$TRAVIS_BUILD_DIR/.scripts
+  - export DRUPAL_DIR=/opt/drupal
 
 install:
-  - $TRAVIS_BUILD_DIR/.scripts/travis_setup.sh
-  - composer install
-  - php vendor/bin/phpcs --config-set installed_paths vendor/drupal/coder/coder_sniffer
-  - cd $HOME/drupal; composer require stomp-php/stomp-php:4.*
+  - $SCRIPT_DIR/travis_setup.sh
+  - cd $DRUPAL_DIR; composer config repositories.1 path "$TRAVIS_BUILD_DIR"
+  - composer require "islandora/islandora:dev-$TRAVIS_COMMIT as dev-8.x-1.x" --prefer-source
+  - cd web; drush en -y islandora
 
 script:
-  - $ISLANDORA_DIR/.scripts/line_endings.sh .
-  - cd $HOME/drupal/modules/islandora
-  - php vendor/bin/phpcs --standard=Drupal --extensions=module/php,php/php src tests
-  - php vendor/bin/phpcpd --names *.module,*.inc,*.test,*.php --exclude=vendor .
-  - cd $HOME/drupal; php core/scripts/run-tests.sh --verbose --php `which php` islandora
+  - $SCRIPT_DIR/line_endings.sh $TRAVIS_BUILD_DIR
+  - phpcs --standard=Drupal --extensions=php,module,inc,install,test,profile,theme,css,info,txt,md $TRAVIS_BUILD_DIR
+  - phpcpd --names *.module,*.inc,*.test,*.php $TRAVIS_BUILD_DIR
+  - php core/scripts/run-tests.sh --verbose --php `which php` islandora
 
 notifications:
   irc:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Islandora
-[![Build Status](https://travis-ci.org/Islandora-CLAW/islandora.png?branch=8.x-1.x)](https://travis-ci.org/Islandora-CLAW/islandora)
-[![Contribution Guidelines](http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg)](./CONTRIBUTING.md)
-[![LICENSE](https://img.shields.io/badge/license-GPLv2-blue.svg?style=flat-square)](./LICENSE)
+[![Build Status][1]](https://travis-ci.org/Islandora-CLAW/islandora)
+[![Contribution Guidelines][2]](./CONTRIBUTING.md)
+[![LICENSE][3]](./LICENSE)
 
 ## Introduction
 
@@ -16,10 +16,22 @@ Current maintainers:
 
 ## Development
 
-If you would like to contribute, please get involved by attending our weekly [Tech Call](https://github.com/Islandora-CLAW/CLAW/wiki). We love to hear from you!
+If you would like to contribute, please get involved by attending our weekly 
+[Tech Call][4]. We love to hear from you!
 
-If you would like to contribute code to the project, you need to be covered by an Islandora Foundation [Contributor License Agreement](http://islandora.ca/sites/default/files/islandora_cla.pdf) or [Corporate Contributor Licencse Agreement](http://islandora.ca/sites/default/files/islandora_ccla.pdf). Please see the [Contributors](http://islandora.ca/resources/contributors) pages on Islandora.ca for more information.
+If you would like to contribute code to the project, you need to be covered by 
+an Islandora Foundation [Contributor License Agreement][5] or 
+[Corporate Contributor License Agreement][6]. Please see the 
+[Contributors][7] pages on Islandora.ca for more information.
 
 ## License
 
 [GPLv2](http://www.gnu.org/licenses/gpl-2.0.txt)
+
+[1]: https://travis-ci.org/Islandora-CLAW/islandora.png?branch=8.x-1.x
+[2]: http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg
+[3]: https://img.shields.io/badge/license-GPLv2-blue.svg?style=flat-square
+[4]: https://github.com/Islandora-CLAW/CLAW/wiki
+[5]: http://islandora.ca/sites/default/files/islandora_cla.pdf
+[6]: http://islandora.ca/sites/default/files/islandora_ccla.pdf
+[7]: http://islandora.ca/resources/contributors


### PR DESCRIPTION
The way were we installing Drupal for travis before was differnt from
how we installed it in the vagrant box. It required manually adding
dependancies for libraries. This should install all the dependancies
using composer automatically.

Came up on this pull request:
https://github.com/Islandora-CLAW/islandora/pull/38

Figured I should break it out to another pull since it got larger then 
I intended it to be.