### PR TITLE
Clean up parents on resource deletion

### DIFF
--- a/src/Entity/FedoraResource.php
+++ b/src/Entity/FedoraResource.php
@@ -225,8 +225,7 @@ class FedoraResource extends ContentEntityBase implements FedoraResourceInterfac
    * {@inheritdoc}
    */
   public function hasParent() {
-    $parent = $this->get('fedora_has_parent')->first();
-    return (!is_null($parent));
+    return (!$this->get('fedora_has_parent')->isEmpty());
   }
 
   /**
@@ -255,7 +254,7 @@ class FedoraResource extends ContentEntityBase implements FedoraResourceInterfac
   /**
    * {@inheritdoc}
    */
-  public function setParent(EntityTypeInterface $entity) {
+  public function setParent(FedoraResourceInterface $entity) {
     $this->set('fedora_has_parent', $entity);
     return $this;
   }

--- a/src/Entity/FedoraResource.php
+++ b/src/Entity/FedoraResource.php
@@ -291,7 +291,7 @@ class FedoraResource extends ContentEntityBase implements FedoraResourceInterfac
    *   An array of node ids
    */
   protected static function getInboundReferences(FedoraResourceInterface $entity) {
-    // TODO: Not use static loading
+    // TODO: Not use static loading.
     $query = $query = \Drupal::entityQuery('fedora_resource');
     $query->condition('fedora_has_parent', $entity->id());
     return $query->execute();

--- a/src/Entity/FedoraResource.php
+++ b/src/Entity/FedoraResource.php
@@ -124,15 +124,15 @@ class FedoraResource extends ContentEntityBase implements FedoraResourceInterfac
     parent::postDelete($storage, $entities);
 
     // This removes references to deleted parents. But this could be
-    // used to remove child nodes instead.
+    // used to remove child entities instead.
     foreach ($entities as $entity) {
       if ($entity->getEntityType()->getBundleEntityType() == 'fedora_resource_type') {
         $references = self::getInboundReferences($entity);
         if ($references) {
-          $nodes = $storage->loadMultiple($references);
-          foreach ($nodes as $node) {
-            $node->removeParent();
-            $node->save();
+          $ref_entities = $storage->loadMultiple($references);
+          foreach ($ref_entities as $ref_entity) {
+            $ref_entity->removeParent();
+            $ref_entity->save();
           }
         }
       }
@@ -288,7 +288,7 @@ class FedoraResource extends ContentEntityBase implements FedoraResourceInterfac
    *   The entity to find inbound references for.
    *
    * @return array
-   *   An array of node ids
+   *   An array of entity ids
    */
   protected static function getInboundReferences(FedoraResourceInterface $entity) {
     // TODO: Not use static loading.

--- a/src/Entity/FedoraResource.php
+++ b/src/Entity/FedoraResource.php
@@ -292,7 +292,7 @@ class FedoraResource extends ContentEntityBase implements FedoraResourceInterfac
    */
   protected static function getInboundReferences(FedoraResourceInterface $entity) {
     // TODO: Not use static loading.
-    $query = $query = \Drupal::entityQuery('fedora_resource');
+    $query = \Drupal::entityQuery('fedora_resource');
     $query->condition('fedora_has_parent', $entity->id());
     return $query->execute();
   }

--- a/src/Entity/FedoraResource.php
+++ b/src/Entity/FedoraResource.php
@@ -281,7 +281,7 @@ class FedoraResource extends ContentEntityBase implements FedoraResourceInterfac
   }
 
   /**
-   * Get all the objects that have $entity as a fedora_has_parent
+   * Get all the objects that have $entity as a fedora_has_parent.
    *
    * @param \Drupal\islandora\FedoraResourceInterface $entity
    *   The entity to find inbound references for.

--- a/src/FedoraResourceInterface.php
+++ b/src/FedoraResourceInterface.php
@@ -115,5 +115,5 @@ interface FedoraResourceInterface extends ContentEntityInterface, EntityChangedI
    *   The called Fedora resource entity.
    */
   public function setParent(FedoraResourceInterface $entity);
-  
+
 }

--- a/src/FedoraResourceInterface.php
+++ b/src/FedoraResourceInterface.php
@@ -4,7 +4,6 @@ namespace Drupal\islandora;
 
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityChangedInterface;
-use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\user\EntityOwnerInterface;
 
 /**
@@ -109,12 +108,12 @@ interface FedoraResourceInterface extends ContentEntityInterface, EntityChangedI
   /**
    * Get the parent entity.
    *
-   * @param \Drupal\Core\Entity\EntityTypeInterface $entity
-   *   The parent entity.
+   * @param \Drupal\islandora\FedoraResourceInterface $entity
+   *    The parent entity.
    *
    * @return \Drupal\islandora\FedoraResourceInterface
    *   The called Fedora resource entity.
    */
-  public function setParent(EntityTypeInterface $entity);
+  public function setParent(FedoraResourceInterface $entity);
 
 }

--- a/src/FedoraResourceInterface.php
+++ b/src/FedoraResourceInterface.php
@@ -109,11 +109,11 @@ interface FedoraResourceInterface extends ContentEntityInterface, EntityChangedI
    * Get the parent entity.
    *
    * @param \Drupal\islandora\FedoraResourceInterface $entity
-   *    The parent entity.
+   *   The parent entity.
    *
    * @return \Drupal\islandora\FedoraResourceInterface
    *   The called Fedora resource entity.
    */
   public function setParent(FedoraResourceInterface $entity);
-
+  
 }

--- a/tests/src/Kernel/DeleteFedoraResourceWithParentsTest.php
+++ b/tests/src/Kernel/DeleteFedoraResourceWithParentsTest.php
@@ -65,6 +65,7 @@ class DeleteFedoraResourceWithParentsTest extends IslandoraKernelTestBase {
       "uid" => $this->user->get('uid'),
       "name" => "Test Child",
       "langcode" => "und",
+      "fedora_has_parent" => $this->parentEntity,
       "status" => 1,
     ]);
     $this->childEntity->save();
@@ -76,23 +77,15 @@ class DeleteFedoraResourceWithParentsTest extends IslandoraKernelTestBase {
    * @covers \Drupal\islandora\Entity\FedoraResource::postDelete
    */
   public function testCleanUpParents() {
-
     $child_id = $this->childEntity->id();
-
-    $this->assertTrue($this->childEntity->get('fedora_has_parent')->isEmpty(), "Should not have a parent.");
-
-    $this->childEntity->set('fedora_has_parent', $this->parentEntity)->save();
-
-    $this->assertFalse($this->childEntity->get('fedora_has_parent')->isEmpty(), "Now we are missing a parent.");
-
-    // This sees the changes from the postDelete, $this->childEntity doesn't.
+    // Load the child entity.
     $new_child = FedoraResource::load($child_id);
-
-    $this->assertFalse($new_child->get('fedora_has_parent')->isEmpty(), "Now we are missing a parent.");
-
+    // Verify it has a parent.
+    $this->assertFalse($new_child->get('fedora_has_parent')->isEmpty(), "Should have a parent.");
+    // Delete the parent entity.
     $this->parentEntity->delete();
-
-    $this->assertTrue($new_child->get('fedora_has_parent')->isEmpty(), "Child should not have a parent.");
+    // Verify we don't have a parent anymore.
+    $this->assertTrue($new_child->get('fedora_has_parent')->isEmpty(), "Should not have a parent.");
 
   }
 

--- a/tests/src/Kernel/DeleteFedoraResourceWithParentsTest.php
+++ b/tests/src/Kernel/DeleteFedoraResourceWithParentsTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Drupal\Tests\islandora\Kernel;
+
+use Drupal\islandora\Entity\FedoraResource;
+use Drupal\simpletest\UserCreationTrait;
+
+/**
+ * Tests the clean up of deleted parent referenced from children.
+ *
+ * @group islandora
+ * @coversDefaultClass \Drupal\islandora\Entity\FedoraResource
+ */
+class DeleteFedoraResourceWithParentsTest extends IslandoraKernelTestBase {
+
+  use UserCreationTrait;
+
+  /**
+   * Parent Fedora resource entity.
+   *
+   * @var \Drupal\islandora\FedoraResourceInterface
+   */
+  protected $parentEntity;
+
+  /**
+   * Child Fedora resource entity.
+   *
+   * @var \Drupal\islandora\FedoraResourceInterface
+   */
+  protected $childEntity;
+
+  /**
+   * User entity.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $user;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+    $permissions = [
+      'add fedora resource entities',
+      'edit fedora resource entities',
+      'delete fedora resource entities',
+    ];
+    $this->assertTrue($this->checkPermissions($permissions), 'Permissions are invalid');
+
+    $this->user = $this->createUser($permissions);
+
+    // Create a test entity.
+    $this->parentEntity = FedoraResource::create([
+      "type" => "rdf_source",
+      "uid" => $this->user->get('uid'),
+      "name" => "Test Parent",
+      "langcode" => "und",
+      "status" => 1,
+    ]);
+    $this->parentEntity->save();
+
+    $this->childEntity = FedoraResource::create([
+      "type" => "rdf_source",
+      "uid" => $this->user->get('uid'),
+      "name" => "Test Child",
+      "langcode" => "und",
+      "status" => 1,
+    ]);
+    $this->childEntity->save();
+  }
+
+  /**
+   * Tests cleaning up child to parent references when parent is deleted.
+   *
+   * @covers \Drupal\islandora\Entity\FedoraResource::postDelete
+   */
+  public function testCleanUpParents() {
+
+    $child_id = $this->childEntity->id();
+
+    $this->assertTrue($this->childEntity->get('fedora_has_parent')->isEmpty(), "Should not have a parent.");
+
+    $this->childEntity->set('fedora_has_parent', $this->parentEntity)->save();
+
+    $this->assertFalse($this->childEntity->get('fedora_has_parent')->isEmpty(), "Now we are missing a parent.");
+
+    // This sees the changes from the postDelete, $this->childEntity doesn't.
+    $new_child = FedoraResource::load($child_id);
+
+    $this->assertFalse($new_child->get('fedora_has_parent')->isEmpty(), "Now we are missing a parent.");
+
+    $this->parentEntity->delete();
+
+    $this->assertTrue($new_child->get('fedora_has_parent')->isEmpty(), "Child should not have a parent.");
+
+  }
+
+}

--- a/tests/src/Kernel/FedoraResourceParentTest.php
+++ b/tests/src/Kernel/FedoraResourceParentTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Drupal\Tests\islandora\Kernel;
+
+use Drupal\islandora\Entity\FedoraResource;
+use Drupal\simpletest\UserCreationTrait;
+
+/**
+ * Tests for adding, removing and testing for parents.
+ *
+ * @group islandora
+ * @coversDefaultClass \Drupal\islandora\Entity\FedoraResource
+ */
+class FedoraResourceParentTest extends IslandoraKernelTestBase {
+
+  use UserCreationTrait;
+
+  /**
+   * A Drupal user.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $user;
+
+  /**
+   * A Fedora Resource.
+   *
+   * @var \Drupal\islandora\Entity\FedoraResource
+   */
+  protected $entity;
+
+  /**
+   * Another Fedora Resource.
+   *
+   * @var \Drupal\islandora\Entity\FedoraResource
+   */
+  protected $parentEntity;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    $permissions = [
+      'add fedora resource entities',
+      'edit fedora resource entities',
+      'delete fedora resource entities',
+    ];
+    $this->assertTrue($this->checkPermissions($permissions), 'Permissions are invalid');
+
+    $this->user = $this->createUser($permissions);
+
+    $this->entity = FedoraResource::create([
+      'type' => 'rdf_source',
+      'uid' => $this->user->get('uid'),
+      'name' => 'Test Entity',
+      'langcode' => 'und',
+      'status' => 1,
+    ]);
+    $this->entity->save();
+
+    $this->parentEntity = FedoraResource::create([
+      'type' => 'rdf_source',
+      'uid' => $this->user->get('uid'),
+      'name' => 'Parent Entity',
+      'langcode' => 'und',
+      'status' => 1,
+    ]);
+    $this->parentEntity->save();
+  }
+
+  /**
+   * @covers \Drupal\islandora\Entity\FedoraResource::setParent
+   */
+  public function testSetParent() {
+    $this->assertTrue($this->entity->get('fedora_has_parent')->isEmpty(), "Entity has an unexpected parent.");
+
+    $this->entity->setParent($this->parentEntity);
+    $this->entity->save();
+
+    $this->assertFalse($this->entity->get('fedora_has_parent')->isEmpty(), "Entity has no parent.");
+  }
+
+  /**
+   * @covers \Drupal\islandora\Entity\FedoraResource::removeParent
+   */
+  public function testRemoveParent() {
+    $this->assertTrue($this->entity->get('fedora_has_parent')->isEmpty(), "Entity has an unexpected parent.");
+
+    $this->entity->set('fedora_has_parent', $this->parentEntity);
+    $this->entity->save();
+
+    $this->assertFalse($this->entity->get('fedora_has_parent')->isEmpty(), "Entity has no parent.");
+
+    $this->entity->removeParent();
+    $this->entity->save();
+
+    $this->assertTrue($this->entity->get('fedora_has_parent')->isEmpty(), "Entity has an unexpected parent.");
+  }
+
+  /**
+   * @covers \Drupal\islandora\Entity\FedoraResource::hasParent
+   */
+  public function testHasParent() {
+    $this->assertTrue($this->entity->get('fedora_has_parent')->isEmpty(), "Entity has an unexpected parent.");
+    $this->assertFalse($this->entity->hasParent(), "hasParent is reporting a parent incorrectly.");
+
+    $this->entity->set('fedora_has_parent', $this->parentEntity);
+    $this->entity->save();
+
+    $this->assertFalse($this->entity->get('fedora_has_parent')->isEmpty(), "Entity has no parent.");
+    $this->assertTrue($this->entity->hasParent(), "hasParent is reporting NO parent incorrectly.");
+
+    $this->entity->set('fedora_has_parent', NULL);
+    $this->entity->save();
+
+    $this->assertTrue($this->entity->get('fedora_has_parent')->isEmpty(), "Entity still has a parent.");
+    $this->assertFalse($this->entity->hasParent(), "hasParent is reporting a parent incorrectly.");
+  }
+
+  /**
+   * @covers \Drupal\islandora\Entity\FedoraResource::getParentId
+   */
+  public function testGetParentId() {
+    $id = $this->parentEntity->id();
+
+    $this->entity->set('fedora_has_parent', $this->parentEntity);
+    $this->entity->save();
+
+    $this->assertEquals($id, $this->entity->getParentId(), "Did not get correct parent id.");
+  }
+
+}


### PR DESCRIPTION
Resolves https://github.com/Islandora-CLAW/CLAW/issues/512

Add remove fedora_has_parent function.

Add query to get all inbound references.

Remove fedora_has_parent if the parent is deleted

Edit: Totally forgot

## How to test
Without PR
1. Create a Fedora Resource
2. Create a second Fedora Resource and set the Has Parent field to the first.
3. Delete the parent Fedora Resource
4. Enjoy broken website

With PR
1. Repeat above 1-3
2. Worky-worky

## What changed?

This adds a `removeParent()` function to the `FedoraResourceInterface` as our `setParent()` requires an `EntityTypeInterface` argument and we use `NULL` to remove the value. 

It also adds a overridden `postDelete()` function which performs a query for all `fedora_resource` entities that have a `fedora_has_parent` field with the delete entities ID.
It then removes the child entities (no deleted) parent (using the new `removeParent`)

The same structure could be used to traverse down and remove all children of an entity.