### PR TITLE
PHP has a odd notion of truth

### DIFF
--- a/src/Plugin/RulesAction/Broadcaster.php
+++ b/src/Plugin/RulesAction/Broadcaster.php
@@ -126,10 +126,10 @@ class Broadcaster extends RulesActionBase implements ContainerFactoryPluginInter
       drupal_set_message(
         t('Error getting JWT token for message. Check JWT Configuration.'), 'error'
       );
+      return;
     }
-    else {
-      $headers['Authorization'] = "Bearer $token";
-    }
+
+    $headers['Authorization'] = "Bearer $token";
 
     // Transform message from string into a proper message object.
     $message = new Message($message, $headers);

--- a/src/Plugin/RulesAction/Broadcaster.php
+++ b/src/Plugin/RulesAction/Broadcaster.php
@@ -118,17 +118,17 @@ class Broadcaster extends RulesActionBase implements ContainerFactoryPluginInter
 
     // Include a token for later authentication in the message.
     $token = $this->auth->generateToken();
-    if ($token !== NULL) {
-      $headers['Authorization'] = "Bearer $token";
-    }
-    else {
+    if (empty($token)) {
       // JWT isn't properly configured. Log and notify user.
       \Drupal::logger('islandora')->error(
-        'Error getting JWT token for message: @msg', ['@msg' => $e->getMessage()]
+        'Error getting JWT token for message: @msg', ['@msg' => $message]
       );
       drupal_set_message(
         t('Error getting JWT token for message. Check JWT Configuration.'), 'error'
       );
+    }
+    else {
+      $headers['Authorization'] = "Bearer $token";
     }
 
     // Transform message from string into a proper message object.

--- a/tests/src/Kernel/BroadcasterTest.php
+++ b/tests/src/Kernel/BroadcasterTest.php
@@ -89,7 +89,7 @@ class BroadcasterTest extends IslandoraKernelTestBase {
         "IslandoraBroadcastRecipients header must be a comma separated list of endpoints"
       );
       $this->assertTrue(
-        strcmp($headers['Authorization'], 'some_token') == 0,
+        strcmp($headers['Authorization'], 'Bearer some_token') == 0,
         "Authorization header must be set"
       );
       $stomp->unsubscribe();

--- a/tests/src/Kernel/BroadcasterTest.php
+++ b/tests/src/Kernel/BroadcasterTest.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\islandora\Kernel;
 use Stomp\Exception\StompException;
 use Stomp\StatefulStomp;
 use Drupal\islandora\Plugin\RulesAction\Broadcaster;
+use Drupal\jwt\Authentication\Provider\JwtAuth;
 
 /**
  * Broadcaster tests.
@@ -87,6 +88,10 @@ class BroadcasterTest extends IslandoraKernelTestBase {
         strcmp($headers['IslandoraBroadcastRecipients'], 'activemq:queue:foo,activemq:queue:bar') == 0,
         "IslandoraBroadcastRecipients header must be a comma separated list of endpoints"
       );
+      $this->assertTrue(
+        strcmp($headers['Authorization'], 'some_token') == 0,
+        "Authorization header must be set"
+      );
       $stomp->unsubscribe();
     }
     catch (StompException $e) {
@@ -106,9 +111,13 @@ class BroadcasterTest extends IslandoraKernelTestBase {
   protected function createBroadcaster(StatefulStomp $stomp) {
     // Pull the plugin definition out of the plugin system.
     $actionManager = $this->container->get('plugin.manager.rules_action');
-    $jwt = $this->container->get('jwt.authentication.jwt');
     $definitions = $actionManager->getDefinitions();
     $pluginDefinition = $definitions['islandora_broadcast'];
+
+    // Mock a JWT generator
+    $prophecy = $this->prophesize(JwtAuth::class);
+    $prophecy->generateToken()->willReturn("some_token");
+    $jwt = $prophecy->reveal();
 
     $action = new Broadcaster(
       [],

--- a/tests/src/Kernel/BroadcasterTest.php
+++ b/tests/src/Kernel/BroadcasterTest.php
@@ -114,7 +114,7 @@ class BroadcasterTest extends IslandoraKernelTestBase {
     $definitions = $actionManager->getDefinitions();
     $pluginDefinition = $definitions['islandora_broadcast'];
 
-    // Mock a JWT generator
+    // Mock a JWT generator.
     $prophecy = $this->prophesize(JwtAuth::class);
     $prophecy->generateToken()->willReturn("some_token");
     $jwt = $prophecy->reveal();


### PR DESCRIPTION
**GitHub Issue**: Islandora-CLAW/CLAW#556

# What does this Pull Request do?

Updates the conditional to check if there's a JWT token to adhere to PHP's ridiculous truthiness.

# What's new?
I changed a direct `NULL` comparison to `empty()`.  This way if JWT configuration is invalid, you'll at least get a flash message and a log entry.

# How should this be tested?

Delete your Key or Secret configuration and then perform a CRUD operation on a FedoraResource entity.  You should see an error message and a watchdog log entry.

# Interested parties
@Islandora-CLAW/committers
