### PR TITLE
issue-560: Updated travis.yml removed php 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: true
 language: php
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1


### PR DESCRIPTION
Removed php 5.5

**GitHub Issue**: (#560)

# What does this Pull Request do?

Remove php 5.5 from travis

# What's new?

Removed php 5.5

# How should this be tested?

Try building with php 5.5 

# Additional Notes:

No additional notes

# Interested parties
@ruebot 
