### PR TITLE
Update to use dev branch of rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - $SCRIPT_DIR/travis_setup_drupal.sh
   - git -C "$TRAVIS_BUILD_DIR" checkout -b travis-testing
   - cd $DRUPAL_DIR; composer config repositories.local path "$TRAVIS_BUILD_DIR"
-  - composer require "islandora/islandora:dev-travis-testing as dev-8.x-1.x" --prefer-source
+  - composer require "islandora/islandora:dev-travis-testing as dev-8.x-1.x" --prefer-source --update-with-dependencies
   - cd web; drush --uri=127.0.0.1:8282 en -y islandora
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   ],
   "require": {
     "drupal/inline_entity_form": "^1.0@beta",
-    "drupal/rules": "^3.0@alpha",
+    "drupal/rules": "3.x-dev",
     "drupal/search_api": "^1.0@beta",
     "islandora/jsonld": "dev-8.x-1.x",
     "stomp-php/stomp-php": "4.*",


### PR DESCRIPTION
## GitHub Issue

Part of:
https://github.com/Islandora-CLAW/CLAW/issues/594

## What does this Pull Request do?

Updates the Islandora `composer.json` to install the dev version of rules that contains the commits needed to run rules on 8.3.x. This is a first step in running Islandora against D8.3.

## Additional Notes:

Not too much has changed in rules, except for the updates to make things work in D8.3, so this should be okay, as long as the Islandora tests pass. 

# Interested parties
@Islandora-CLAW/committers