### PR TITLE
Updating rules to publish events to new routes

### DIFF
--- a/config/install/rules.reaction.broadcast_create_event.yml
+++ b/config/install/rules.reaction.broadcast_create_event.yml
@@ -45,7 +45,7 @@ expression:
         uuid: 2afa7216-91bb-49a3-a567-e504ba8f95e1
         context_values:
           recipients:
-            - "activemq:queue:islandora-indexing-fcrepo\r"
+            - "activemq:queue:islandora-indexing-fcrepo-create\r"
             - 'activemq:queue:islandora-indexing-triplestore'
         context_mapping:
           message: event_message

--- a/config/install/rules.reaction.broadcast_delete_event.yml
+++ b/config/install/rules.reaction.broadcast_delete_event.yml
@@ -45,7 +45,7 @@ expression:
         uuid: 53942d65-7567-4b6b-9b43-4d67079651f6
         context_values:
           recipients:
-            - "activemq:queue:islandora-indexing-fcrepo\r"
+            - "activemq:queue:islandora-indexing-fcrepo-delete\r"
             - 'activemq:queue:islandora-indexing-triplestore'
         context_mapping:
           message: event_message

--- a/config/install/rules.reaction.broadcast_update_event.yml
+++ b/config/install/rules.reaction.broadcast_update_event.yml
@@ -45,7 +45,7 @@ expression:
         uuid: 40aa4a03-ad36-45bf-9584-ede3b9b3e5c9
         context_values:
           recipients:
-            - "activemq:queue:islandora-indexing-fcrepo\r"
+            - "activemq:queue:islandora-indexing-fcrepo-update\r"
             - 'activemq:queue:islandora-indexing-triplestore'
         context_mapping:
           message: event_message

--- a/islandora.info.yml
+++ b/islandora.info.yml
@@ -17,3 +17,4 @@ dependencies:
   - search_api
   - jwt
   - media_entity_image
+  - rest 

--- a/tests/src/Kernel/IslandoraKernelTestBase.php
+++ b/tests/src/Kernel/IslandoraKernelTestBase.php
@@ -25,6 +25,7 @@ abstract class IslandoraKernelTestBase extends KernelTestBase {
     'inline_entity_form',
     'serialization',
     'rest',
+    'hal',
     'rdf',
     'typed_data',
     'rules',


### PR DESCRIPTION
**GitHub Issue**: Part of Islandora-CLAW/CLAW#597

* Other Relevant Links 

Blocks an upcoming PR on Alpaca.

# What does this Pull Request do?

Updates configuration to point to new queues by default for fcrepo indexing.

# What's new?
Updated yaml.

# How should this be tested?

* Uninstall islandora and its dependent modules
* `git pull` in this code
* Re-install islandora and its dependent modules
* Clear the drupal cache
* Go to the rules config and look up the `broadcast_*_event` rules.  They should be pointing to separate queues for each type of operation.  That is, `broadcast_create_event` should have `islandora-indexing-fcrepo-create` as one of its recipients.  `broadcast_update_event` should have `islandora-indexing-fcrepo-update` and `broadcast_delete_event` should have `islandora-indexing-fcrepo-delete` as recipients.

# Additional Notes:
There's a pending PR on Alpaca that will utilize these queues.

# Interested parties
@Islandora-CLAW/committers
