### PR TITLE
Using hook_modules_installed instead of hook_install to force rest co…

### DIFF
--- a/islandora.install
+++ b/islandora.install
@@ -5,8 +5,6 @@
  * Install/update hook implementations.
  */
 
-use Drupal\rest\Entity\RestResourceConfig;
-
 /**
  * Implements hook_schema().
  */
@@ -41,20 +39,4 @@ function islandora_schema() {
     ],
   ];
   return $schema;
-}
-
-/**
- * Implemets hook_install().
- */
-function islandora_install() {
-  $rest_config = RestResourceConfig::load('entity.node');
-
-  $configuration = [
-    'methods' => ['GET', 'POST', 'PATCH', 'DELETE'],
-    'formats' => ['hal_json', 'jsonld'],
-    'authentication' => ['basic_auth', 'jwt_auth', 'cookie'],
-  ];
-
-  $rest_config->set('configuration', $configuration);
-  $rest_config->save(TRUE);
 }

--- a/islandora.module
+++ b/islandora.module
@@ -41,7 +41,13 @@ function islandora_help($route_name, RouteMatchInterface $route_match) {
 function islandora_modules_installed($modules) {
   // Ensure the auth and serialization formats we need are available.
   if (in_array('rest', $modules)) {
-    $rest_config = RestResourceConfig::load('entity.node');
+    $rest_resource_config_storage = \Drupal::service('entity_type.manager')->getStorage('rest_resource_config');
+
+    $rest_resource_config = $rest_resource_config_storage->load('entity.node');
+
+    if (!$rest_resource_config) {
+      $rest_resource_config = $rest_resource_config_storage->create(['id' => 'entity.node']);
+    }
 
     $configuration = [
       'methods' => ['GET', 'POST', 'PATCH', 'DELETE'],
@@ -49,8 +55,8 @@ function islandora_modules_installed($modules) {
       'authentication' => ['basic_auth', 'jwt_auth', 'cookie'],
     ];
 
-    $rest_config->set('configuration', $configuration);
-    $rest_config->save(TRUE);
+    $rest_resource_config->set('configuration', $configuration);
+    $rest_resource_config->save(TRUE);
   }
 }
 

--- a/islandora.module
+++ b/islandora.module
@@ -17,6 +17,7 @@
 use Drupal\Core\Database\IntegrityConstraintViolationException;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\rest\Entity\RestResourceConfig;
 
 /**
  * Implements hook_help().
@@ -27,10 +28,29 @@ function islandora_help($route_name, RouteMatchInterface $route_match) {
     case 'help.page.islandora':
       $output = '';
       $output .= '<h3>' . t('About') . '</h3>';
-      $output .= '<p>' . t('This is a placeholder for future help text about Islandora.') . '</p>';
+      $output .= '<p>' . t('Islandora integrates Drupal with a Fedora repository.') . '</p>';
       return $output;
 
     default:
+  }
+}
+
+/**
+ * Implements hook_modules_installed().
+ */
+function islandora_modules_installed($modules) {
+  // Ensure the auth and serialization formats we need are available.
+  if (in_array('rest', $modules) {
+    $rest_config = RestResourceConfig::load('entity.node');
+
+    $configuration = [
+      'methods' => ['GET', 'POST', 'PATCH', 'DELETE'],
+      'formats' => ['hal_json', 'jsonld'],
+      'authentication' => ['basic_auth', 'jwt_auth', 'cookie'],
+    ];
+
+    $rest_config->set('configuration', $configuration);
+    $rest_config->save(TRUE);
   }
 }
 

--- a/islandora.module
+++ b/islandora.module
@@ -17,7 +17,6 @@
 use Drupal\Core\Database\IntegrityConstraintViolationException;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
-use Drupal\rest\Entity\RestResourceConfig;
 
 /**
  * Implements hook_help().
@@ -42,21 +41,22 @@ function islandora_modules_installed($modules) {
   // Ensure the auth and serialization formats we need are available.
   if (in_array('rest', $modules)) {
     $rest_resource_config_storage = \Drupal::service('entity_type.manager')->getStorage('rest_resource_config');
-
     $rest_resource_config = $rest_resource_config_storage->load('entity.node');
 
-    if (!$rest_resource_config) {
-      $rest_resource_config = $rest_resource_config_storage->create(['id' => 'entity.node']);
+    if ($rest_resource_config) {
+      $configuration = $rest_resource_config->get('configuration');
+
+      if (!in_array('jsonld', $configuration['formats'])) {
+        $configuration['formats'][] = 'jsonld';
+      }
+
+      if (!in_array('jwt_auth', $configuration['authentication'])) {
+        $configuration['authentication'][] = 'jwt_auth';
+      }
+
+      $rest_resource_config->set('configuration', $configuration);
+      $rest_resource_config->save(TRUE);
     }
-
-    $configuration = [
-      'methods' => ['GET', 'POST', 'PATCH', 'DELETE'],
-      'formats' => ['hal_json', 'jsonld'],
-      'authentication' => ['basic_auth', 'jwt_auth', 'cookie'],
-    ];
-
-    $rest_resource_config->set('configuration', $configuration);
-    $rest_resource_config->save(TRUE);
   }
 }
 

--- a/islandora.module
+++ b/islandora.module
@@ -40,7 +40,7 @@ function islandora_help($route_name, RouteMatchInterface $route_match) {
  */
 function islandora_modules_installed($modules) {
   // Ensure the auth and serialization formats we need are available.
-  if (in_array('rest', $modules) {
+  if (in_array('rest', $modules)) {
     $rest_config = RestResourceConfig::load('entity.node');
 
     $configuration = [

--- a/tests/src/Kernel/EventGeneratorTestBase.php
+++ b/tests/src/Kernel/EventGeneratorTestBase.php
@@ -34,7 +34,7 @@ abstract class EventGeneratorTestBase extends IslandoraKernelTestBase {
     parent::setUp();
 
     // Create a test user.
-    $this->user = $this->createUser(['add fedora resource entities']);
+    $this->user = $this->createUser(['administer nodes']);
 
     $test_type = NodeType::create([
       'type' => 'test_type',


### PR DESCRIPTION
…nfig

**GitHub Issue**: Islandora-CLAW/CLAW#643

# What does this Pull Request do?

Moves forcing `rest` config for nodes from `hook_install` to `hook_modules_installed`.

# How should this be tested?

A happy Travis is all we need here.

# Interested parties
@Islandora-CLAW/committers
