### PR TITLE
Add hook_install for rest configuration

### DIFF
--- a/islandora.install
+++ b/islandora.install
@@ -40,3 +40,28 @@ function islandora_schema() {
   ];
   return $schema;
 }
+
+/**
+ * Implements hook_install().
+ */
+function islandora_install() {
+  if (\Drupal::moduleHandler()->moduleExists('rest')) {
+    $rest_resource_config_storage = \Drupal::service('entity_type.manager')->getStorage('rest_resource_config');
+    $rest_resource_config = $rest_resource_config_storage->load('entity.node');
+
+    if ($rest_resource_config) {
+      $configuration = $rest_resource_config->get('configuration');
+
+      if (!in_array('jsonld', $configuration['formats'])) {
+        $configuration['formats'][] = 'jsonld';
+      }
+
+      if (!in_array('jwt_auth', $configuration['authentication'])) {
+        $configuration['authentication'][] = 'jwt_auth';
+      }
+
+      $rest_resource_config->set('configuration', $configuration);
+      $rest_resource_config->save(TRUE);
+    }
+  }
+}


### PR DESCRIPTION
**GitHub Issue**: None

# What does this Pull Request do?

Adds a `hook_install` which is a copy of @dannylamb's `hook_modules_installed`.

# How should this be tested?

I did this.
1. `vagrant destroy`
2. `git pull` (to make sure I was up-to-date)
3. edit `../scripts/drupal.sh` at line 91 below
```
## THIS IS STUPID
# blocks are tied to themes because themes define the regions available to place blocks. gross.
##
```
   and above
```
$DRUSH_CMD en -y islandora
$DRUSH_CMD en -y islandora_collection
$DRUSH_CMD en -y islandora_image
```
I added
```
### StartOfInsanity
## This is Jared's Hack to load his test branch
## it should not exist elsewhere
cd "$DRUPAL_HOME/web/modules/contrib"
rm -rf islandora
git clone https://github.com/whikloj/islandora-1.git --branch install-patch islandora
### EndOfInsanity
```

4. do `vagrant up`
5. When vagrant is finished, login and go to **Admin -> Configuration -> REST**

Beside **Content** you should see `jsonld` under `format` and `jwt_auth` under `Authentication`.
![claw](https://user-images.githubusercontent.com/2857697/26902980-f09fef1e-4ba0-11e7-8a8d-cfb8aebff605.jpg)

# Interested parties
@Islandora-CLAW/committers
