### PR TITLE
Expose parent collection as link header

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -122,7 +122,7 @@ function islandora_node_delete(EntityInterface $entity) {
  */
 function islandora_node_view_alter(&$build, EntityInterface $entity) {
   // Return if memberof field does not exist.
-  if ($entity->hasField('field_memberof') == false) {
+  if ($entity->hasField('field_memberof') == FALSE) {
     return;
   }
 
@@ -133,8 +133,8 @@ function islandora_node_view_alter(&$build, EntityInterface $entity) {
   }
 
   // Loop through each member and add to the collection_links.
-  $collection_links =  [];
-  foreach ($collection_members as &$member_info) {
+  $collection_links = [];
+  foreach ($collection_members as $member_info) {
     $collection_id = $member_info['target_id'];
     $collection_entity = $entity->load($collection_id);
 

--- a/islandora.module
+++ b/islandora.module
@@ -116,3 +116,47 @@ function islandora_node_delete(EntityInterface $entity) {
   $versionCounter = \Drupal::service('islandora.versioncounter');
   $versionCounter->delete($entity->uuid());
 }
+
+/**
+ * Implements hook_node_view_alter().
+ */
+function islandora_node_view_alter(&$build, EntityInterface $entity) {
+  // Return if memberof field does not exist.
+  if ($entity->hasField('field_memberof') == false) {
+    return;
+  }
+
+  // Return if memberof field has no values.
+  $collection_members = $entity->get('field_memberof')->getValue();
+  if (count($collection_members) == 0) {
+    return;
+  }
+
+  // Loop through each member and add to the collection_links.
+  $collection_links =  [];
+  foreach ($collection_members as &$member_info) {
+    $collection_id = $member_info['target_id'];
+    $collection_entity = $entity->load($collection_id);
+
+    // If collection entity does not exist, skip.
+    if ($collection_entity == NULL) {
+      continue;
+    }
+
+    // If entity bundle type is not Collection, skip.
+    $collection_entity_bundle = $collection_entity->bundle();
+    if ($collection_entity_bundle != "islandora_collection") {
+      continue;
+    }
+
+    $collection_entity_url = $collection_entity->url('canonical', ['absolute' => TRUE]);
+    array_push($collection_links, "<" . $collection_entity_url . ">; rel='collection'");
+  }
+
+  if (count($collection_links) > 0) {
+    $collection_links_str = implode(", ", $collection_links);
+    $build['#attached']['http_header'] = [
+      ['Link', $collection_links_str],
+    ];
+  }
+}


### PR DESCRIPTION
**GitHub Issue**: (link)
* https://github.com/Islandora-CLAW/CLAW/issues/680

# What does this Pull Request do?
If a drupal content type has "field_memberof" field pointing to islandora_collection entities, then it will add the url to those entities as link header using the hook_node_view_alter.  

# How should this be tested?
* Get the PR
* Create an islandora image node with field_memberof pointing to an existing collection
* Issue a `curl -I` request to the newly created node and get the header info
* Verify that the link info is included in the header, similar to below:
```
$ curl -I http://localhost:8000/node/2
HTTP/1.1 200 OK
---
Link: <http://localhost:8000/node/1>; rel='collection', <http://localhost:8000/node/3>; rel='collection'
Link: </node/2>; rel="canonical"
Link: </node/2>; rel="shortlink"
Link: </node/2>; rel="revision"
Content-Type: text/html; charset=UTF-8
```
* Load other content type nodes, verify no error messages are thrown

# Interested parties
@whikloj @dannylamb @DiegoPino 

