### PR TITLE
Referenced Media Condition

### DIFF
--- a/config/schema/islandora.schema.yml
+++ b/config/schema/islandora.schema.yml
@@ -53,6 +53,13 @@ condition.plugin.is_media:
   type: condition.plugin
   mapping:
 
+condition.plugin.is_referenced_media:
+  type: condition.plugin
+  mapping:
+    field:
+      type: text
+      label: 'Reference Field'
+
 condition.plugin.is_file:
   type: condition.plugin
   mapping:

--- a/src/Plugin/Condition/IsReferencedMedia.php
+++ b/src/Plugin/Condition/IsReferencedMedia.php
@@ -175,12 +175,13 @@ class IsReferencedMedia extends ConditionPluginBase implements ContainerFactoryP
    * {@inheritdoc}
    */
   public function evaluate() {
-    // Check to see that the media is referenced by a node using the specified
-    // field.
+    // Check to see that the media is referenced by a node of the specified
+    // type using the specified field.
     $media = $this->getContextValue('media');
     $field_key = $this->configuration['field'];
-    list($bundle, $field) = explode('|', $field_key);
+    list($content_type, $field) = explode('|', $field_key);
     return $this->entityQuery->get('node')
+      ->condition('type', $content_type)
       ->condition("$field.target_id", $media->id())
       ->execute();
   }

--- a/src/Plugin/Condition/IsReferencedMedia.php
+++ b/src/Plugin/Condition/IsReferencedMedia.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace Drupal\islandora\Plugin\Condition;
+
+use Drupal\Core\Condition\ConditionPluginBase;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityFieldManager;
+use Drupal\Core\Entity\Query\QueryFactory;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\media_entity\MediaInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Condition to see if a Media is referenced by a Node using a particular field.
+ *
+ * @Condition(
+ *   id = "is_referenced_media",
+ *   label = @Translation("Is Referenced Media"),
+ *   context = {
+ *     "media" = @ContextDefinition("entity:media", label = @Translation("Media"))
+ *   }
+ * )
+ */
+class IsReferencedMedia extends ConditionPluginBase implements ContainerFactoryPluginInterface{
+
+  /**
+   * Content type storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $contentTypeStorage;
+
+  /**
+   * The entity field manager.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $entityFieldManager;
+
+  /**
+   * Entity query service.
+   *
+   * @var \Drupal\Core\Entity\Query\QueryFactory
+   */
+  protected $entityQuery;
+
+  /**
+   * Creates a new IsReferencedMedia instance.
+   *
+   * @param \Drupal\Core\Entity\EntityStorageInterface $content_type_storage
+   *   Content type storage.
+   * @param \Drupal\Core\Entity\EntityFieldManager $entity_field_manager
+   *   The entity field manager.
+   * @param \Drupal\Core\Entity\Query\QueryFactory $entity_query
+   *   Entity query service.
+   * @param array $configuration
+   *   The plugin configuration, i.e. an array with configuration values keyed
+   *   by configuration option name. The special key 'context' may be used to
+   *   initialize the defined contexts by setting it to an array of context
+   *   values keyed by context names.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   */
+  public function __construct(
+    EntityStorageInterface $content_type_storage,
+    EntityFieldManager $entity_field_manager,
+    QueryFactory $entity_query,
+    array $configuration,
+    $plugin_id,
+    $plugin_definition
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->contentTypeStorage = $content_type_storage;
+    $this->entityFieldManager = $entity_field_manager;
+    $this->entityQuery = $entity_query;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $container->get('entity_type.manager')->getStorage('node_type'),
+      $container->get('entity_field.manager'),
+      $container->get('entity.query'),
+      $configuration,
+      $plugin_id,
+      $plugin_definition
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    // Get all entity reference fields that target Media.
+    $media_reference_fields = $this->entityQuery->get('field_storage_config')
+      ->condition('entity_type', 'node')
+      ->condition('type', 'entity_reference')
+      ->condition('settings.target_type', 'media')
+      ->execute();
+
+    // Trim off the preceding 'node.'
+    $media_reference_fields = array_map(
+      function ($field) {
+        return ltrim($field, 'node.');
+      },
+      $media_reference_fields
+    );
+
+    // Flip the results so it can be used in an array_intersect_key later on.
+    $media_reference_fields = array_flip($media_reference_fields);
+
+    // Get all content types.
+    $content_types = $this->contentTypeStorage->loadMultiple();
+
+    // Build up the 2D options array.
+    $options = [];
+    foreach ($content_types as $content_type) {
+      // Filter fields to those we know are media references.
+      $all_fields = $this->entityFieldManager->getFieldDefinitions('node', $content_type->id());
+      $reference_fields = array_intersect_key($all_fields, $media_reference_fields);
+
+      // First dimension is keyed by the content type label.
+      // Second dimension is keyed by the content_type machine name concatenated
+      // with the field name.  The content type machine name is needed for
+      // disambiguation, otherwise fields attached to multiple content types
+      // have unexpected behaviour when submitting the form.
+      foreach ($reference_fields as $field_name => $field_definition) {
+        $content_type_label = $content_type->label();
+        $field_key = $content_type->id() . '|' . $field_name;
+        $field_label = $field_definition->getLabel();
+        $options[$content_type_label][$field_key] = $field_label;
+      }
+    }
+
+    // Create the 2D select.
+    $form['field'] = [
+      '#title' => $this->t('Referenced As'),
+      '#description' => $this->t('The field that references the Media.'),
+      '#type' => 'select',
+      '#options' => $options,
+      '#default_value' => isset($this->configuration['field']) ? $this->configuration['field'] : '',
+      '#size' => 10,
+    ];
+
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    $this->configuration['field'] = $form_state->getValue('field');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return ['field' => ''] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function summary() {
+    return $this->t('The Media is referenced by a Node using the specified field.');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function evaluate() {
+    // Check to see that the media is referenced by a node using the specified
+    // field.
+    $media = $this->getContextValue('media');
+    $field_key = $this->configuration['field'];
+    list($bundle, $field) = explode('|', $field_key);
+    return $this->entityQuery->get('node')
+      ->condition("$field.target_id", $media->id())
+      ->execute();
+  }
+
+}

--- a/src/Plugin/Condition/IsReferencedMedia.php
+++ b/src/Plugin/Condition/IsReferencedMedia.php
@@ -8,8 +8,6 @@ use Drupal\Core\Entity\EntityFieldManager;
 use Drupal\Core\Entity\Query\QueryFactory;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\Core\Field\FieldDefinitionInterface;
-use Drupal\media_entity\MediaInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -23,7 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   }
  * )
  */
-class IsReferencedMedia extends ConditionPluginBase implements ContainerFactoryPluginInterface{
+class IsReferencedMedia extends ConditionPluginBase implements ContainerFactoryPluginInterface {
 
   /**
    * Content type storage.
@@ -104,7 +102,7 @@ class IsReferencedMedia extends ConditionPluginBase implements ContainerFactoryP
       ->condition('settings.target_type', 'media')
       ->execute();
 
-    // Trim off the preceding 'node.'
+    // Trim off the preceding 'node.'.
     $media_reference_fields = array_map(
       function ($field) {
         return ltrim($field, 'node.');

--- a/tests/src/Functional/IsReferencedMediaTest.php
+++ b/tests/src/Functional/IsReferencedMediaTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Drupal\Tests\islandora\Functional;
+
+use Drupal\field\Tests\EntityReference\EntityReferenceTestTrait;
+use Drupal\Tests\media_entity\Functional\MediaEntityFunctionalTestTrait;
+
+/**
+ * Tests the IsReferencedMedia condition.
+ *
+ * @group islandora
+ */
+class IsReferencedMediaTest extends IslandoraFunctionalTestBase {
+
+  use EntityReferenceTestTrait;
+  use MediaEntityFunctionalTestTrait;
+
+  /**
+   * Media to be referenced.
+   *
+   * @var \Drupal\media\MediaInterface
+   */
+  protected $referenced;
+
+  /**
+   * An unreferenced media to use as a control.
+   *
+   * @var \Drupal\media\MediaInterface
+   */
+  protected $notReferenced;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    // Create a test content type with a media reference field.
+    $test_type_with_reference = $this->container->get('entity_type.manager')->getStorage('node_type')->create([
+      'type' => 'test_type_with_reference',
+      'label' => 'Test Type With Reference',
+    ]);
+    $test_type_with_reference->save();
+    $this->createEntityReferenceField('node', 'test_type_with_reference', 'field_media', 'Media Entity', 'media', 'default', [], 2);
+
+    // Create two media.
+    $media_bundle = $this->drupalCreateMediaBundle();
+    $this->referenced = $this->container->get('entity_type.manager')->getStorage('media')->create([
+      'bundle' => $media_bundle->id(),
+      'name' => 'Referenced Media',
+    ]);
+    $this->referenced->save();
+
+    $this->notReferenced = $this->container->get('entity_type.manager')->getStorage('media')->create([
+      'bundle' => $media_bundle->id(),
+      'name' => 'Unreferenced Media',
+    ]);
+    $this->notReferenced->save();
+
+    // Reference one in a node.
+    $node = $this->container->get('entity_type.manager')->getStorage('node')->create([
+      'type' => 'test_type_with_reference',
+      'title' => 'Referencer',
+      'field_media' => [$this->referenced->id()],
+    ]);
+    $node->save();
+  }
+
+  /**
+   * @covers \Drupal\islandora\ContextProvider\MediaContextProvider::__construct
+   * @covers \Drupal\islandora\ContextProvider\MediaContextProvider::getRuntimeContexts
+   * @covers \Drupal\islandora\IslandoraContextManager::evaluateContexts
+   * @covers \Drupal\islandora\IslandoraContextManager::applyContexts
+   * @covers \Drupal\islandora\Plugin\Condition\IsReferencedMedia::evaluate
+   * @covers \Drupal\islandora\Plugin\Condition\IsReferencedMedia::buildConfigurationForm
+   * @covers \Drupal\islandora\Plugin\Condition\IsReferencedMedia::submitConfigurationForm
+   * @covers \Drupal\islandora\Plugin\Condition\IsReferencedMedia::evaluate
+   * @covers \Drupal\islandora\PresetReaction\PresetReaction::buildConfigurationForm
+   * @covers \Drupal\islandora\PresetReaction\PresetReaction::submitConfigurationForm
+   * @covers \Drupal\islandora\PresetReaction\PresetReaction::execute
+   * @covers \Drupal\islandora\IslandoraServiceProvider::alter
+   */
+  public function testIsReferencedMedia() {
+    // Create a test user.
+    $account = $this->drupalCreateUser([
+      'administer contexts',
+      'view media',
+      'update any media',
+    ]);
+    $this->drupalLogin($account);
+
+    $this->createContext('Test', 'test');
+
+    // Add the condition.
+    $this->drupalGet("admin/structure/context/test/condition/add/is_referenced_media");
+    $this->getSession()->getPage()->findById("edit-conditions-is-referenced-media-field")->selectOption('test_type_with_reference|field_media');
+    $this->getSession()->getPage()->pressButton('Save and continue');
+
+    // Add the reaction to say "Hello World!".
+    $this->addPresetReaction('test', 'index', 'hello_world');
+
+    // Edit the referenced node.  "Hello World!" should be output to the screen.
+    $this->postEntityEditForm("media/{$this->referenced->id()}", ['name[0][value]' => 'Referenced Media Changed'], 'Save and keep published');
+    $this->assertSession()->pageTextContains("Hello World!");
+
+    // Edit the unreferenced node.  "Hello World!" should not be output to the
+    // screen.
+    $this->postEntityEditForm("media/{$this->notReferenced->id()}", ['name[0][value]' => 'Unreferenced Media Changed'], 'Save and keep published');
+    $this->assertSession()->pageTextNotContains("Hello World!");
+  }
+
+}


### PR DESCRIPTION
**GitHub Issue**: Resolves https://github.com/Islandora-CLAW/CLAW/issues/795

# What does this Pull Request do?

Adds a Condition that can be used with the Context UI module to filter Media based on what type of node is referncing them and what field is being used to do so. 

# What's new?

* An IsReferencedMedia Condition plugin
* Functional tests
* Updated schema.yml for the new Condition

# How should this be tested?

- Uninstall `islandora`: https://gist.github.com/whikloj/614fa21d7145b09197fd1e8513dd2f41
- `cd /var/www/html/drupal/web/modules/contrib/islandora`
- `sudo git remote add danny https://github.com/dannylamb/islandora.git`
- `sudo git fetch danny`
- `sudo git checkout media-bundle-condition`
- `drush en islandora`
- `drush en context_ui`

Now that it's all set up, you can take it for a test drive.  I did this by making an Action that dsm's some text to the screen so we can trigger it on index events.
- Visit `config/system/actions` and select 'Dispaly a message to the user...' from the dropdown and hit 'Create'
![screenshot from 2018-02-06 16-55-03](https://user-images.githubusercontent.com/20773151/35883898-4f079d76-0b5f-11e8-86cb-0bdb157a3412.png)
- Name it and give it some text to print
![screenshot from 2018-02-06 16-55-37](https://user-images.githubusercontent.com/20773151/35883917-5d50af6c-0b5f-11e8-8b27-afb37fd15348.png)

Then set up the context.
- Visit http://localhost:8000/admin/structure/context and add a new Context.  I made mine to check for thumbnails.
![screenshot from 2018-02-06 16-52-50](https://user-images.githubusercontent.com/20773151/35883942-72a917e6-0b5f-11e8-8b4e-b56ffeee514c.png)
- Add the 'Is Referenced Media' Condition to the Context by clicking 'Add condition' and selecting it from the list
![screenshot from 2018-02-06 16-53-29](https://user-images.githubusercontent.com/20773151/35883982-8c5af45c-0b5f-11e8-9b33-9295b6651e95.png)
- Select the field you want the Media referenced by from the select box
![screenshot from 2018-02-06 16-53-54](https://user-images.githubusercontent.com/20773151/35884016-a3910530-0b5f-11e8-8ea5-cc9f7af810d8.png)
- Add an Index reaction to the Context by clicking 'Add reaction' and selecting it from the list
![screenshot from 2018-02-06 16-54-15](https://user-images.githubusercontent.com/20773151/35884059-ba81100a-0b5f-11e8-867b-644cbb5c223a.png)
- Select the Action you made to print text to the screen.  It should be under the 'System' heading
![screenshot from 2018-02-06 16-56-07](https://user-images.githubusercontent.com/20773151/35884089-d185cee4-0b5f-11e8-9230-1997f7c1b258.png)
- Save the context
- Make an Islandora Image with a Thumbnail media
![screenshot from 2018-02-06 16-57-01](https://user-images.githubusercontent.com/20773151/35884125-f9484128-0b5f-11e8-83bb-22eda4bb2c6f.png)
- Edit the Media, either directly or through the inline entity form on the node.  I did it through the node and just changed the alt text by adding an exclamation point at the end.
![screenshot from 2018-02-06 16-58-19](https://user-images.githubusercontent.com/20773151/35884184-362ace8a-0b60-11e8-99db-1acd5fe2a81a.png)
- You should see your message displayed on the screen
![screenshot from 2018-02-06 16-58-32](https://user-images.githubusercontent.com/20773151/35884205-50f3738e-0b60-11e8-90e2-c89ea4ca4bb9.png)

You can do other things like create unreferenced Media and make sure the message isn't printed to the screen.  Or you can add a new content type and re-use the thumbnail field.  Editing a Media referenced by the other content type also should not trigger the message.  The functional tests in this PR are running all these scenarios if you're curious.

# Interested parties
@Islandora-CLAW/committers Here's another one we'll need for derivatives.
