### PR TITLE
Add binary to node

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ Example usage:
 curl -u admin:islandora -v -X PUT -H 'Content-Type: image/png' -H 'Content-Disposition: attachment; filename="my_image.png"' --data-binary @my_image.png localhost:8000/media/1/source
 ```
 
+### /node/{node}/media/{field}/add/{bundle}
+
+You can POST content to the `/node/{node}/media/{field}/add/{bundle}` endpoint to create a new Media of the specified bundle
+using the POST body.  It will be associated with the specified Node using the field from the route. The `Content-Type`
+header is expected, as well as a `Content-Disposition` header of the form `attachment; filename="your_filename"` to indicate
+the name to give the file.  Requests with empty bodies or no `Content-Length` header will be rejected.
+
+Example usage:
+```
+curl -v -u admin:islandora -H "Content-Type: image/jpeg" -H "Content-Disposition: attachment; filename=\"test.jpeg\"" --data-binary @test.jpeg http://localhost:8000/node/1/media/my_media_field/add/my_media_bundle
+```
+
 ## Maintainers
 
 Current maintainers:

--- a/islandora.routing.yml
+++ b/islandora.routing.yml
@@ -33,3 +33,13 @@ islandora.media_source_update:
     _permission: 'update media'
   options:
     _auth: ['basic_auth', 'cookie', 'jwt_auth']
+
+islandora.media_source_add_to_node:
+  path: '/node/{node}/media/{field}/add/{bundle}'
+  defaults:
+    _controller: '\Drupal\islandora\Controller\MediaSourceController::addToNode'
+  methods: [POST]
+  requirements:
+    _permission: 'create media'
+  options:
+    _auth: ['basic_auth', 'cookie', 'jwt_auth']

--- a/islandora.routing.yml
+++ b/islandora.routing.yml
@@ -40,6 +40,6 @@ islandora.media_source_add_to_node:
     _controller: '\Drupal\islandora\Controller\MediaSourceController::addToNode'
   methods: [POST]
   requirements:
-    _permission: 'create media'
+    _custom_access: '\Drupal\islandora\Controller\MediaSourceController::addToNodeAccess'
   options:
     _auth: ['basic_auth', 'cookie', 'jwt_auth']

--- a/islandora.services.yml
+++ b/islandora.services.yml
@@ -41,5 +41,4 @@ services:
       - { name: 'context_provider' }
   islandora.media_source_service:
     class: Drupal\islandora\MediaSource\MediaSourceService
-    factory: ['Drupal\islandora\MediaSource\MediaSourceService', create]
-    arguments: ['@entity_type.manager', '@stream_wrapper_manager']
+    arguments: ['@entity_type.manager', '@current_user', '@stream_wrapper_manager', '@token']

--- a/src/Controller/MediaSourceController.php
+++ b/src/Controller/MediaSourceController.php
@@ -5,7 +5,6 @@ namespace Drupal\islandora\Controller;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Database\Connection;
 use Drupal\media_entity\MediaInterface;
-use Drupal\media_entity\Entity\MediaBundle;
 use Drupal\node\NodeInterface;
 use Drupal\islandora\MediaSource\MediaSourceService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -130,6 +129,23 @@ class MediaSourceController extends ControllerBase {
     }
   }
 
+  /**
+   * Adds a Media to a Node using the specified field.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The Node to which you want to add a Media.
+   * @param string $field
+   *   Name of field on Node to reference Media.
+   * @param string $bundle
+   *   Name of bundle for Media to create.
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request object.
+   *
+   * @return \Symfony\Component\HttpFoundation\Response
+   *   201 on success with a Location link header.
+   *
+   * @throws \Symfony\Component\HttpKernel\Exception\HttpException
+   */
   public function addToNode(
     NodeInterface $node,
     $field,
@@ -188,4 +204,5 @@ class MediaSourceController extends ControllerBase {
       throw new HttpException(500, $e->getMessage());
     }
   }
+
 }

--- a/src/Controller/MediaSourceController.php
+++ b/src/Controller/MediaSourceController.php
@@ -2,8 +2,11 @@
 
 namespace Drupal\islandora\Controller;
 
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Database\Connection;
+use Drupal\Core\Routing\RouteMatch;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\media_entity\MediaInterface;
 use Drupal\node\NodeInterface;
 use Drupal\islandora\MediaSource\MediaSourceService;
@@ -203,6 +206,24 @@ class MediaSourceController extends ControllerBase {
       $transaction->rollBack();
       throw new HttpException(500, $e->getMessage());
     }
+  }
+
+  /**
+   * Checks for permissions to update a node and create media.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   Account for user making the request.
+   * @param \Drupal\Core\Routing\RouteMatch $route_match
+   *   Route match to get Node from url params.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   Access result.
+   */
+  public function addToNodeAccess(AccountInterface $account, RouteMatch $route_match) {
+    // We'd have 404'd already if node didn't exist, so no need to check.
+    // Just hack it out of the route match.
+    $node = $route_match->getParameter('node');
+    return AccessResult::allowedIf($node->access('update', $account) && $account->hasPermission('create media'));
   }
 
 }

--- a/src/MediaSource/MediaSourceService.php
+++ b/src/MediaSource/MediaSourceService.php
@@ -2,11 +2,16 @@
 
 namespace Drupal\islandora\MediaSource;
 
+use Drupal\Component\Render\PlainTextOutput;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StreamWrapper\StreamWrapperManager;
+use Drupal\Core\Utility\Token;
 use Drupal\media_entity\MediaInterface;
+use Drupal\node\NodeInterface;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -16,18 +21,18 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class MediaSourceService {
 
   /**
-   * Media bundle storage.
+   * The entity type manager.
    *
-   * @var \Drupal\Core\Entity\EntityStorageInterface
+   * @var \Drupal\Core\Entity\EntityTypeManager
    */
-  protected $mediaBundleStorage;
+  protected $entityTypeManager;
 
   /**
-   * Field config storage.
+   * Current user.
    *
-   * @var \Drupal\Core\Entity\EntityStorageInterface
+   * @var \Drupal\Core\Session\AccountInterface
    */
-  protected $fieldConfigStorage;
+  protected $account;
 
   /**
    * Stream wrapper manager.
@@ -37,45 +42,32 @@ class MediaSourceService {
   protected $streamWrapperManager;
 
   /**
-   * Constructor.
+   * Token service.
    *
-   * @param \Drupal\Core\Entity\EntityStorageInterface $media_bundle_storage
-   *   Media bundle storage.
-   * @param \Drupal\Core\Entity\EntityStorageInterface $field_config_storage
-   *   Field config storage.
-   * @param \Drupal\Core\StreamWrapper\StreamWrapperManager $stream_wrapper_manager
-   *   Stream wrapper manager.
+   * @var \Drupal\Core\Utility\Token
    */
-  public function __construct(
-    EntityStorageInterface $media_bundle_storage,
-    EntityStorageInterface $field_config_storage,
-    StreamWrapperManager $stream_wrapper_manager
-  ) {
-    $this->mediaBundleStorage = $media_bundle_storage;
-    $this->fieldConfigStorage = $field_config_storage;
-    $this->streamWrapperManager = $stream_wrapper_manager;
-  }
+  protected $token;
 
   /**
-   * Factory.
+   * Constructor.
    *
    * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
    *   The entity type manager.
    * @param \Drupal\Core\StreamWrapper\StreamWrapperManager $stream_wrapper_manager
    *   Stream wrapper manager.
-   *
-   * @return \Drupal\islandora\MediaSource\MediaSourceService
-   *   MediaSourceService instance.
+   * @param \Drupal\Core\Utility\Token $token
+   *   Token service.
    */
-  public static function create(
+  public function __construct(
     EntityTypeManager $entity_type_manager,
-    StreamWrapperManager $stream_wrapper_manager
+    AccountInterface $account,
+    StreamWrapperManager $stream_wrapper_manager,
+    Token $token
   ) {
-    return new static(
-      $entity_type_manager->getStorage('media_bundle'),
-      $entity_type_manager->getStorage('field_config'),
-      $stream_wrapper_manager
-    );
+    $this->entityTypeManager = $entity_type_manager;
+    $this->account = $account;
+    $this->streamWrapperManager = $stream_wrapper_manager;
+    $this->token = $token;
   }
 
   /**
@@ -88,7 +80,7 @@ class MediaSourceService {
    *   Field name if it exists in configuration, else NULL.
    */
   public function getSourceFieldName($media_bundle) {
-    $bundle = $this->mediaBundleStorage->load($media_bundle);
+    $bundle = $this->entityTypeManager->getStorage('media_bundle')->load($media_bundle);
     $type_configuration = $bundle->getTypeConfiguration();
 
     if (!isset($type_configuration['source_field'])) {
@@ -96,27 +88,6 @@ class MediaSourceService {
     }
 
     return $type_configuration['source_field'];
-  }
-
-  /**
-   * Gets a list of valid file extensions for a field.
-   *
-   * @param string $entity_type
-   *   Entity type (node, media, etc...).
-   * @param string $bundle
-   *   Bundle the field belongs to.
-   * @param string $field
-   *   The field whose valid extensions you're looking for.
-   *
-   * @return string
-   *   Space delimited string containing valid extensions.
-   */
-  public function getFileFieldExtensions($entity_type, $bundle, $field) {
-    $field_config = $this->fieldConfigStorage->load("$entity_type.$bundle.$field");
-    if (!$field_config) {
-      return "";
-    }
-    return $field_config->getSetting('file_extensions');
   }
 
   /**
@@ -157,18 +128,29 @@ class MediaSourceService {
     $file->setMimeType($mimetype);
     $file->setFilename($filename);
     $file->setSize($content_length);
+    $file->save();
 
     // Validate file extension.
-    $entity_type = $media->getEntityTypeId();
     $bundle = $media->bundle();
-    $valid_extensions = $this->getFileFieldExtensions($entity_type, $bundle, $source_field);
+    $source_field_config = $this->entityTypeManager->getStorage('field_config')->load("media.$bundle.$source_field");
+    $valid_extensions = $source_field_config->getSetting('file_extensions');
     $errors = file_validate_extensions($file, $valid_extensions);
 
     if (!empty($errors)) {
       throw new BadRequestHttpException("Invalid file extension.  Valid types are :$valid_extensions");
     }
 
-    // Copy the contents over using streams.
+    // Set fields provided by type plugin and mapped in bundle configuration
+    // for the media.
+    foreach ($media->bundle->entity->field_map as $source => $destination) {
+      if ($media->hasField($destination) && $value = $media->getType()->getField($media, $source)) {
+        $media->set($destination, $value);
+      }
+    }
+    $media->save();
+
+    // Copy the contents over using streams. Do this last since it's not
+    // covered under the transaction.
     $uri = $file->getFileUri();
     $file_stream_wrapper = $this->streamWrapperManager->getViaUri($uri);
     $path = "";
@@ -177,7 +159,78 @@ class MediaSourceService {
     if (stream_copy_to_stream($resource, $file_stream) === FALSE) {
       throw new HttpException(500, "The file could not be copied into $uri");
     }
+
+    // Flush the image cache for the image so thumbnails get regenerated.
+    image_path_flush($uri);
+  }
+
+  public function addToNode(
+    NodeInterface $node,
+    $field,
+    $bundle,
+    $resource,
+    $mimetype,
+    $content_length,
+    $filename
+  ) {
+    if (!$node->hasField($field)) {
+      throw new NotFoundHttpException();
+    }
+
+    if (!$node->get($field)->isEmpty()) {
+      throw new ConflictHttpException();
+    }
+
+    // Get the source field for the media type.
+    $source_field = $this->getSourceFieldName($bundle);
+    if (empty($source_field)) {
+      throw new NotFoundHttpException("Source field not set for {$media->bundle()} media");
+    }
+
+    // Load its config to get file extensions and upload path.
+    $source_field_config = $this->entityTypeManager->getStorage('field_config')->load("media.$bundle.$source_field");
+
+    // Construct the destination uri. 
+    $directory = $source_field_config->getSetting('file_directory');
+    $directory = trim($directory, '/');
+    $directory = PlainTextOutput::renderFromHtml($this->token->replace($directory, ['node' => $node]));
+    $scheme = file_default_scheme();
+    $destination = "$scheme://$directory/$filename";
+
+    // Construct the File.
+    $file = $this->entityTypeManager->getStorage('file')->create([
+      'uid' => $this->account->id(),
+      'uri' => $destination,
+      'filename' => $filename,
+      'filemime' => $mimetype,
+      'filesize' => $content_length,
+      'status' => FILE_STATUS_PERMANENT,
+    ]);
+
+    // Validate file extension.
+    $source_field_config = $this->entityTypeManager->getStorage('field_config')->load("media.$bundle.$source_field");
+    $valid_extensions = $source_field_config->getSetting('file_extensions');
+    $errors = file_validate_extensions($file, $valid_extensions);
+
+    if (!empty($errors)) {
+      throw new BadRequestHttpException("Invalid file extension.  Valid types are $valid_extensions");
+    }
+
     $file->save();
+
+    // Construct the Media.
+    $media_struct = [
+      'bundle' => $bundle,
+      'uid' => $this->account->id(),
+      'name' => $filename,
+      "$source_field" => [
+        'target_id' => $file->id(),
+      ],
+    ];
+    if ($source_field_config->getSetting('alt_field') && $source_field_config->getSetting('alt_field_required')) {
+      $media_struct[$source_field]['alt'] = $filename;
+    }
+    $media = $this->entityTypeManager->getStorage('media')->create($media_struct);
 
     // Set fields provided by type plugin and mapped in bundle configuration
     // for the media.
@@ -191,6 +244,23 @@ class MediaSourceService {
     image_path_flush($uri);
 
     $media->save();
-  }
 
+    // Update the Node.
+    $node->get($field)->appendItem($media);
+    $node->save();
+
+    // Copy the contents over using streams. Do this last since it's not
+    // covered under the transaction.
+    $uri = $file->getFileUri();
+    $file_stream_wrapper = $this->streamWrapperManager->getViaUri($uri);
+    $path = "";
+    $file_stream_wrapper->stream_open($uri, 'w', STREAM_REPORT_ERRORS, $path);
+    $file_stream = $file_stream_wrapper->stream_cast(STREAM_CAST_AS_STREAM);
+    if (stream_copy_to_stream($resource, $file_stream) === FALSE) {
+      throw new HttpException(500, "The file could not be copied into $uri");
+    }
+
+    // Return the created media.
+    return $media;
+  }
 }

--- a/tests/src/Functional/AddMediaToNodeTest.php
+++ b/tests/src/Functional/AddMediaToNodeTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Drupal\Tests\islandora\Functional;
+
+use Drupal\Core\Url;
+use Drupal\field\Tests\EntityReference\EntityReferenceTestTrait;
+use Drupal\Tests\media_entity\Functional\MediaEntityFunctionalTestTrait;
+
+/**
+ * Tests the RelatedLinkHeader view alter.
+ *
+ * @group islandora
+ */
+class AddMediaToNodeTest extends IslandoraFunctionalTestBase {
+
+  use EntityReferenceTestTrait;
+
+  /**
+   * Node that has entity reference field.
+   *
+   * @var \Drupal\node\NodeInterface
+   */
+  protected $referencer;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    // Create a test content type with an entity reference field.
+    $test_type_with_reference = $this->container->get('entity_type.manager')->getStorage('node_type')->create([
+      'type' => 'test_type_with_reference',
+      'label' => 'Test Type With Reference',
+    ]);
+    $test_type_with_reference->save();
+
+    // Add two entity reference fields.
+    // One for nodes and one for media.
+    $this->createEntityReferenceField('node', 'test_type_with_reference', 'field_media', 'Media Entity', 'media', 'default', [], 2);
+
+    $this->referencer = $this->container->get('entity_type.manager')->getStorage('node')->create([
+      'type' => 'test_type_with_reference',
+      'title' => 'Referencer',
+    ]);
+    $this->referencer->save();
+  }
+
+  public function testAddMediaToNode() {
+    $account = $this->drupalCreateUser([
+      'bypass node access',
+      'view media',
+      'create media',
+      'update media',
+    ]);
+    $this->drupalLogin($account);
+    
+    // Hack out the guzzle client.
+    $client = $this->getSession()->getDriver()->getClient()->getClient();
+
+    $add_to_node_url = Url::fromRoute(
+      'islandora.media_source_add_to_node',
+      ['node' => $this->referencer->id(), 'field' => 'field_media', 'bundle' => 'tn']
+    )
+    ->setAbsolute()
+    ->toString();
+
+    $image = file_get_contents(__DIR__ . '/../../static/test.jpeg');
+
+    $options = [
+      'auth' => [$account->getUsername(), $account->pass_raw],
+      'http_errors' => FALSE,
+      'headers' => [
+        'Content-Type' => 'image/jpeg',
+        'Content-Disposition' => 'attachment; filename="test.jpeg"',
+      ],
+      'body' => $image,
+    ];
+    $response = $client->request('POST', $add_to_node_url, $options);
+    $this->assertTrue($response->getStatusCode() == 201, "Unsuccessful");
+  }
+}
+

--- a/tests/src/Functional/MediaSourceControllerTest.php
+++ b/tests/src/Functional/MediaSourceControllerTest.php
@@ -107,7 +107,6 @@ class MediaSourceControllerTest extends IslandoraFunctionalTestBase {
     $this->assertTrue($response->getStatusCode() == 400, "Expected 400, received {$response->getStatusCode()}");
 
     // Update without body should fail with 400.
-    $options = [
       'auth' => [$account->getUsername(), $account->pass_raw],
       'http_errors' => FALSE,
       'headers' => [
@@ -145,14 +144,13 @@ class MediaSourceControllerTest extends IslandoraFunctionalTestBase {
     $updated_image = file_get_contents($updated['field_image'][0]['url']);
 
     $this->assertTrue($original_mimetype != $updated_mimetype, "Mimetypes should be updated with media source update");
-    $this->assertTrue($original_width != $updated_width, "Height should be updated with media source update");
-    $this->assertTrue($original_height != $updated_height, "Width should be updated with media source update");
-    $this->assertTrue($original_image != $updated_image, "Width should be updated with media source update");
+    $this->assertTrue($original_width != $updated_width, "Width should be updated with media source update");
+    $this->assertTrue($original_height != $updated_height, "Height should be updated with media source update");
+    $this->assertTrue($original_image != $updated_image, "Image should be updated with media source update");
 
     $this->assertTrue($updated_mimetype == "image/jpeg", "Invalid mimetype.  Expected image/jpeg, received $updated_mimetype");
     $this->assertTrue($updated_width == 295, "Invalid width.  Expected 295, received $updated_width");
     $this->assertTrue($updated_height == 70, "Invalid height.  Expected 70, received $updated_height");
     $this->assertTrue($updated_image == file_get_contents(__DIR__ . '/../../static/test.jpeg'), "Updated image not the same as PUT body.");
   }
-
 }

--- a/tests/src/Functional/MediaSourceUpdateTest.php
+++ b/tests/src/Functional/MediaSourceUpdateTest.php
@@ -9,7 +9,7 @@ use Drupal\Core\Url;
  *
  * @group islandora
  */
-class MediaSourceControllerTest extends IslandoraFunctionalTestBase {
+class MediaSourceUpdateTest extends IslandoraFunctionalTestBase {
 
   /**
    * {@inheritdoc}
@@ -99,7 +99,7 @@ class MediaSourceControllerTest extends IslandoraFunctionalTestBase {
       'http_errors' => FALSE,
       'headers' => [
         'Content-Type' => 'image/jpeg',
-        'Content-Disposition' => 'attachment; garbage="test.jpeg"',
+        'Content-Disposition' => 'garbage; filename="test.jpeg"',
       ],
       'body' => $image,
     ];
@@ -107,6 +107,7 @@ class MediaSourceControllerTest extends IslandoraFunctionalTestBase {
     $this->assertTrue($response->getStatusCode() == 400, "Expected 400, received {$response->getStatusCode()}");
 
     // Update without body should fail with 400.
+    $options = [
       'auth' => [$account->getUsername(), $account->pass_raw],
       'http_errors' => FALSE,
       'headers' => [
@@ -153,4 +154,5 @@ class MediaSourceControllerTest extends IslandoraFunctionalTestBase {
     $this->assertTrue($updated_height == 70, "Invalid height.  Expected 70, received $updated_height");
     $this->assertTrue($updated_image == file_get_contents(__DIR__ . '/../../static/test.jpeg'), "Updated image not the same as PUT body.");
   }
+
 }


### PR DESCRIPTION
**GitHub Issue**: Resolves https://github.com/Islandora-CLAW/CLAW/issues/796, depends on https://github.com/Islandora-Devops/claw-playbook/pull/57

# What does this Pull Request do?

Adds a route that lets users add new Media to Nodes by issuing POST requests.

# What's new?
A new controller method and custom access check. The route is located at `node/{node}/media/{field}/add/{bundle}`. There's tests to assert the following behaviours:

- It returns 404 if none of the route parameters exist in Drupal.
- It returns 403 if you do not have permissions to update the Node nor create a Media entity.
- It requires a request body, returning 400 if missing.
- It expects a `Content-Disposition` header of the form `attachment; filename="your_filename_with_extension"`, returning 400 if missing.
- It expects a `Content-Type` header, returning 400 if missing.
- It returns 201 on success, with a `Location` header pointing to the created Media.
- If the Node already has a Media referenced by the specified field, it returns 409 (Conflict).  If you want to update an existing media, PUT content to the `/media/{media}/source` route from https://github.com/Islandora-CLAW/CLAW/issues/787 instead.

# How should this be tested?

Pull down this code, and clear drupal caches and routing.
- `drupal cache:rebuild all`
- `drupal router:rebuild`

Using ths JSON:
```json
{
   "type":[
      {
         "target_id":"islandora_image",
         "target_type":"node_type"
      }
   ],
   "title":[
      {
         "value":"Title goes here."
      }
   ],
   "field_description":[
      {
         "value":"Description goes here."
      }
   ]
}
```

Create a new `islandora_image` node using the REST api: 
- Save the JSON to a file, I named mine `image.json`.
```
curl -u admin:islandora -H "Content-Type: application/json" --data-binary @image.json -v localhost:8000/node
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 8000 (#0)
* Server auth using Basic with user 'admin'
> POST /node HTTP/1.1
> Host: localhost:8000
> Authorization: Basic YWRtaW46aXNsYW5kb3Jh
> User-Agent: curl/7.47.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 272
> 
* upload completely sent off: 272 out of 272 bytes
< HTTP/1.1 201 Created
< Date: Mon, 12 Feb 2018 15:18:05 GMT
< Server: Apache/2.4.18 (Ubuntu)
< X-Powered-By: PHP/7.0.22-0ubuntu0.16.04.1
< Location: http://localhost:8000/node/4
< Cache-Control: must-revalidate, no-cache, private
< X-UA-Compatible: IE=edge
< Content-language: en
< X-Content-Type-Options: nosniff
< X-Frame-Options: SAMEORIGIN
< Expires: Sun, 19 Nov 1978 05:00:00 GMT
< X-Generator: Drupal 8 (https://www.drupal.org)
< Content-Length: 1145
< Content-Type: application/json
< 
{"nid":[{"value":4}],"uuid":[{"value":"42045e71-5672-4068-88fe-81d0a1c6d563"}],"vid":[{"value":6}],"langcode":[{"value":"en"}],"type":[{"target_id":"islandora_image","target_type":"node_type","target_uuid":"a1746dab-a9c1-4716-86b8-f7ee220a1c46"}],"revision_timestamp":[{"value":"2018-02-12T15:18:05+00:00","format":"Y-m-d\\TH:i:sP"}],"revision_uid":[{"target_id":1,"target_type":"user","target_uuid":"a18b74b4-22a0-446d-ab39-1e9b46dc7c39","url":"\/user\/1"}],"revision_log":[],"status":[{"value":true}],"title":[{"value":"Title goes here."}],"uid":[{"target_id":1,"target_type":"user","target_uuid":"a18b74b4-22a0-446d-ab39-1e9b46dc7c39","url":"\/user\/1"}],"created":[{"value":"2018-02-12T15:18:05+00:00","format":"Y-m-d\\TH:i:sP"}],"changed":[{"value":"2018-02-12T15:18:05+00:00","format":"Y-m-d\\TH:i:sP"}],"promote":[{"value":true}],"sticky":[{"value":false}],"default_langcode":[{"value":true}],"revision_translation_affected":[{"value":true}],"path":[{"alias":null,"pid":null,"langcode":"en"}],"field_description":[{"v* Connection #0 to host localhost left intact
alue":"Description goes here."}],"field_jp2":[],"field_memberof":[],"field_tiff":[],"field_tn":[],"field_web_content":[]}
```

In the response, you should be given a `Location` header telling you where the new Node is located. Mine was `Location: http://localhost:8000/node/4`.  Check out the node, it should be blank except for the title and descriptions we supplied in the JSON.

Now we can add a Media by supplying a binary to a route that contains the Media bundle to create an the field to reference it with.  To add a Tiff, the route would be `http://localhost:8000/node/4/media/field_tiff/add/image_tiff`.  To add a regular png or jpeg, you would use `http://localhost:8000/node/4/media/field_web_content/add/web_content` 

Let's try it out with a JPEG.  Assuming we have a jpeg named `test.jpeg`:
```
daniel@daniel-Latitude-3560:~/Pictures$ curl -v -u admin:islandora -H "Content-Type: image/jpeg" -H "Content-Disposition: attachment; filename=\"test.jpeg\"" --data-binary @test.jpeg http://localhost:8000/node/4/media/field_web_content/add/web_content
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 8000 (#0)
* Server auth using Basic with user 'admin'
> POST /node/4/media/field_web_content/add/web_content HTTP/1.1
> Host: localhost:8000
> Authorization: Basic YWRtaW46aXNsYW5kb3Jh
> User-Agent: curl/7.47.0
> Accept: */*
> Content-Type: image/jpeg
> Content-Disposition: attachment; filename="test.jpeg"
> Content-Length: 7119
> Expect: 100-continue
> 
< HTTP/1.1 100 Continue
* We are completely uploaded and fine
< HTTP/1.1 201 Created
< Date: Mon, 12 Feb 2018 15:34:44 GMT
< Server: Apache/2.4.18 (Ubuntu)
< X-Powered-By: PHP/7.0.22-0ubuntu0.16.04.1
< Cache-Control: must-revalidate, no-cache, private
< Location: http://localhost:8000/media/3
< X-UA-Compatible: IE=edge
< Content-language: en
< X-Content-Type-Options: nosniff
< X-Frame-Options: SAMEORIGIN
< Expires: Sun, 19 Nov 1978 05:00:00 GMT
< X-Generator: Drupal 8 (https://www.drupal.org)
< Content-Length: 0
< Content-Type: text/html; charset=UTF-8
< 
* Connection #0 to host localhost left intact
```

Your new Media's url is returned as the `Location` header in the response.  Mine was `Location: http://localhost:8000/media/3`.  Now go visit the media and check out the node to make sure it's referenced.

# Interested parties
@Islandora-CLAW/committers
