### PR TITLE
provide namespace configuration

### DIFF
--- a/config/install/islandora.settings.yml
+++ b/config/install/islandora.settings.yml
@@ -3,3 +3,17 @@ fedora_rest_endpoint: 'http://localhost:8080/fcrepo/rest'
 _core:
   default_config_hash: nDZDR2rrpXXQ-D_7BYrdDFAXYOsB5hgH6vCAMV5I3w8
 broadcast_queue: islandora-connector-broadcast
+
+rdf_namespaces: >
+  ldp  => http://www.w3.org/ns/ldp#,
+  dc11 => http://purl.org/dc/elements/1.1/,
+  nfo => http://www.semanticdesktop.org/ontologies/2007/03/22/nfo/v1.1/,
+  ebucore => http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#,
+  fedora => http://fedora.info/definitions/v4/repository#,
+  owl => http://www.w3.org/2002/07/owl#,
+  ore => http://www.openarchives.org/ore/terms/,
+  rdf => http://www.w3.org/1999/02/22-rdf-syntax-ns#,
+  islandora => http://islandora.ca/CLAW/,
+  pcdm => http://pcdm.org/models#,
+  use => http://pcdm.org/use#,
+  iana => http://www.iana.org/assignments/relation/,

--- a/islandora.module
+++ b/islandora.module
@@ -66,23 +66,18 @@ function islandora_modules_installed($modules) {
  * Implements hook_rdf_namespaces().
  */
 function islandora_rdf_namespaces() {
-  // Yes, it's amazing, rdf is not registered by default!
-  return [
-    'ldp'  => 'http://www.w3.org/ns/ldp#',
-    'dc11' => 'http://purl.org/dc/elements/1.1/',
-    'nfo' => 'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo/v1.1/',
-    'ebucore' => 'http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#',
-    'fedora' => 'http://fedora.info/definitions/v4/repository#',
-    'owl' => 'http://www.w3.org/2002/07/owl#',
-    'ore' => 'http://www.openarchives.org/ore/terms/',
-    'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
-    'islandora' => 'http://islandora.ca/CLAW/',
-    'pcdm' => 'http://pcdm.org/models#',
-    'use' => 'http://pcdm.org/use#',
-    'iana' => 'http://www.iana.org/assignments/relation/',
-  ];
-}
+  $config = \Drupal::config('islandora.settings');
+  $rdf_namespaces = $config->get('rdf_namespaces');
 
+  $entries = explode(',', $rdf_namespaces);
+  $prefix_namespace_list = array();
+  foreach ($entries as $item) {
+    $prefix_namespace = explode("=>",$item);
+    $prefix_namespace_list[trim($prefix_namespace[0])] = trim($prefix_namespace[1]);
+  }
+
+  return $prefix_namespace_list;
+}
 /**
  * Implements hook_entity_insert().
  */

--- a/src/Form/IslandoraSettingsForm.php
+++ b/src/Form/IslandoraSettingsForm.php
@@ -15,6 +15,7 @@ class IslandoraSettingsForm extends ConfigFormBase {
 
   const CONFIG_NAME = 'islandora.settings';
   const BROKER_URL = 'broker_url';
+  const RDF_NAMESPACES = 'rdf_namespaces';
 
   /**
    * {@inheritdoc}
@@ -42,6 +43,12 @@ class IslandoraSettingsForm extends ConfigFormBase {
       '#type' => 'textfield',
       '#title' => $this->t('Broker URL'),
       '#default_value' => $config->get(self::BROKER_URL),
+    ];
+
+    $form[self::RDF_NAMESPACES] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('RDF Namespaces'),
+      '#default_value' => $config->get(self::RDF_NAMESPACES),
     ];
 
     return parent::buildForm($form, $form_state);
@@ -84,6 +91,7 @@ class IslandoraSettingsForm extends ConfigFormBase {
 
     $config
       ->set(self::BROKER_URL, $form_state->getValue(self::BROKER_URL))
+      ->set(self::RDF_NAMESPACES, $form_state->getValue(self::RDF_NAMESPACES))
       ->save();
 
     parent::submitForm($form, $form_state);


### PR DESCRIPTION
**GitHub Issue**: (link)

* Other Relevant Links
```
14:27 <Natkeeran> whikloj: is there any way to add new prefixes
14:27 <Natkeeran> whikloj: example dbpedia-owl, custom
14:28 -!- dwilcox [~dwilcox@134.41.58.226] has quit [Quit: My MacBook Pro has gone to sleep. ZZZzzz…]
14:28 <whikloj> Natkeeran: yes through a hook, we could probably refactor it to use an admin page if you want to build one :)
14:28 <whikloj> https://github.com/Islandora-CLAW/islandora/blob/8.x-1.x/islandora.module#L68
14:29 <Natkeeran> whikloj: Is this dynamic, meaning, jsonld pulls it when it needs it?
14:29 <Natkeeran> whikloj: yes, I can make that configurable
14:30 <whikloj> Natkeeran: that is used by the rdf module and in the serializer we make use of the rdf_get_namespaces function to get an array of prefix => uri
14:31 <whikloj> Natkeeran: I don't know if rdf_get_namespaces calls all hooks each time, I imagine there is some cache we would need to clear
14:31 <Natkeeran> whikloj: basically, If I register an array variable and set that array variable via admin page, after cache clear, that should do it, right?
```

# What does this Pull Request do?
Currently, if user uses non configured prefixes in the rdf mapping, resulting jsonld does not contain the the expanded uri for the properties.  This can complicate quering.  The prefix -> namespace mapping is currently hard coded in here:  https://github.com/Islandora-CLAW/islandora/blob/8.x-1.x/islandora.module#L68

This PR attempts to make that array configurable via UI.  

# What's new?
This PR changes the hard coded array in `islandora_rdf_namespaces` to a dynamically created array from a string configured via UI.

* Need to verify if this the best approach to represent array.
* Need to verify that performance implications are acceptable.  

# How should this be tested?
* [Uninstall islandora](https://gist.github.com/whikloj/614fa21d7145b09197fd1e8513dd2f41)
* Install this PR
* Verify that default namespaces are set here: http://localhost:8000/admin/config/islandora/core
* Add a new namespace and corresponding rdf mapping 
* Clear cache
* Verify that jsonld has the expanded property uri (example: dbpedia-owl => http://dbpedia.org/ontology/, dbpedia-owl: notes, should result in:

```
http://dbpedia.org/ontology/description |  
@value | "sample notes"
@type | "http://www.w3.org/2001/XMLSchema#string"
```


# Interested parties
@whikloj @dannylamb 