### PR TITLE
No longer forcing REST config, README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,18 @@ CLAW's core Islandora module for Drupal 8.x
 ## Installation
 
 For a fully automated install, see [claw-playbook](https://github.com/Islandora-Devops/claw-playbook).  If you're installing
-manually, the REST configuration for both Nodes and Media need to be enabled with `jwt_auth` for authentication and both
-`json` and `jsonld` formats. 
+manually, then _at a minimum_, the REST configuration for Nodes, Media, and Files need to be enabled with `jwt_auth` for
+authentication on all methods.  The `json` and `jsonld` formats need to be enabled for for GET requests.  Only the `json` fomat
+is required for POST, PATCH, and DELETE requests.
+
+This can be done using the Rest UI module by setting granularity to 'Method'.  If you want to use GET requests through a browser,
+you'll want to enable `cookie` authentication. And if you want to use a username/password with cURL, you'll want to enable `basic
+authentication`.
+
+If you want to import the configuration through Drupal's configuration synchronization tools, you can use these yaml files
+from claw-playbook for [Nodes](https://github.com/Islandora-Devops/claw-playbook/blob/master/roles/internal/webserver-app/files/rest.resource.entity.node.yml),
+[Media](https://github.com/Islandora-Devops/claw-playbook/blob/master/roles/internal/webserver-app/files/rest.resource.entity.media.yml),
+and [Files](https://github.com/Islandora-Devops/claw-playbook/blob/master/roles/internal/webserver-app/files/rest.resource.entity.file.yml).
 
 ## REST API
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This can be done using the Rest UI module by setting granularity to 'Method'.  I
 you'll want to enable `cookie` authentication. And if you want to use a username/password with cURL, you'll want to enable `basic
 authentication`.
 
+![screenshot from 2018-03-09 10-09-57](https://user-images.githubusercontent.com/20773151/37212586-caf31dc8-2385-11e8-8122-1608dacbfb5f.png)
+
 If you want to import the configuration through Drupal's configuration synchronization tools, you can use these yaml files
 from claw-playbook for [Nodes](https://github.com/Islandora-Devops/claw-playbook/blob/master/roles/internal/webserver-app/files/rest.resource.entity.node.yml),
 [Media](https://github.com/Islandora-Devops/claw-playbook/blob/master/roles/internal/webserver-app/files/rest.resource.entity.media.yml),

--- a/islandora.module
+++ b/islandora.module
@@ -37,32 +37,6 @@ function islandora_help($route_name, RouteMatchInterface $route_match) {
 }
 
 /**
- * Implements hook_modules_installed().
- */
-function islandora_modules_installed($modules) {
-  // Ensure the auth and serialization formats we need are available.
-  if (in_array('rest', $modules)) {
-    $rest_resource_config_storage = \Drupal::service('entity_type.manager')->getStorage('rest_resource_config');
-    $rest_resource_config = $rest_resource_config_storage->load('entity.node');
-
-    if ($rest_resource_config) {
-      $configuration = $rest_resource_config->get('configuration');
-
-      if (!in_array('jsonld', $configuration['formats'])) {
-        $configuration['formats'][] = 'jsonld';
-      }
-
-      if (!in_array('jwt_auth', $configuration['authentication'])) {
-        $configuration['authentication'][] = 'jwt_auth';
-      }
-
-      $rest_resource_config->set('configuration', $configuration);
-      $rest_resource_config->save(TRUE);
-    }
-  }
-}
-
-/**
  * Implements hook_rdf_namespaces().
  */
 function islandora_rdf_namespaces() {


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/813

# What does this Pull Request do?

Removes a previous attempt at forcing configuration, and instead provides
installation instructions through the README.

# What's new?

* Less cruft
* More docs

# How should this be tested?

Read the doc updates?  The weird code I removed is pointless now that there's documentation.

# Interested parties
@Islandora-CLAW/committers
