### PR TITLE
Fixing WSOD when term has no uri

### DIFF
--- a/src/EventSubscriber/LinkHeaderSubscriber.php
+++ b/src/EventSubscriber/LinkHeaderSubscriber.php
@@ -203,9 +203,9 @@ abstract class LinkHeaderSubscriber implements EventSubscriberInterface {
             $rel = "tag";
             $entity_url = $referencedEntity->url('canonical', ['absolute' => TRUE]);
             if ($referencedEntity->hasField('field_external_uri')) {
-              $external_uri = $referencedEntity->get('field_external_uri')->first()->getValue()['uri'];
-              if (!empty($external_uri)) {
-                $entity_url = $external_uri;
+              $external_uri = $referencedEntity->get('field_external_uri')->getValue();
+              if (!empty($external_uri) && isset($external_uri[0]['uri'])) {
+                $entity_url = $external_uri[0]['uri'];
               }
             }
             $title = $referencedEntity->label();


### PR DESCRIPTION
**GitHub Issue**: Resolves https://github.com/Islandora-CLAW/CLAW/issues/852

# What does this Pull Request do?

Adds an extra step of checks to not blow up when viewing content tagged with terms that have no external uri.

# How should this be tested?

- Make a new taxonomy term, but don't give it an external uri.
- Make a new node and tag it with that term.
- Try and visit the term... KABOOM
```
ubuntu@claw:/var/www/html/drupal/web/modules/contrib/islandora/src$ curl -I localhost:8000/node/1
HTTP/1.0 500 500 Service unavailable (with message)
Date: Fri, 22 Jun 2018 02:50:02 GMT
Server: Apache/2.4.18 (Ubuntu)
X-Powered-By: PHP/7.0.30-0ubuntu0.16.04.1
Cache-Control: no-cache, private
Connection: close
Content-Type: text/html; charset=UTF-8
```
- Apply this PR
- `drupal cr all`
- Now go and visit.  The term's internal URI should be used in the link header with `rel="tag"`.
```
ubuntu@claw:/var/www/html/drupal/web/modules/contrib/islandora/src$ curl -I localhost:8000/node/1
HTTP/1.1 200 OK
Date: Fri, 22 Jun 2018 02:49:37 GMT
Server: Apache/2.4.18 (Ubuntu)
X-Powered-By: PHP/7.0.30-0ubuntu0.16.04.1
Cache-Control: must-revalidate, no-cache, private
Link: <http://localhost:8000/taxonomy/term/19>; rel="tag"; title="Derp"
Link: <http://localhost:8000/node/1?_format=jsonld>; rel="alternate"; type="application/ld+json"
Link: <http://localhost:8000/node/1?_format=json>; rel="alternate"; type="application/json"
Link: </node/1>; rel="canonical"
Link: </node/1>; rel="shortlink"
Link: </node/1>; rel="revision"
Link: </node?node=1>; rel="create"
X-Drupal-Dynamic-Cache: MISS
X-UA-Compatible: IE=edge
Content-language: en
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
Expires: Sun, 19 Nov 1978 05:00:00 GMT
Vary: 
X-Generator: Drupal 8 (https://www.drupal.org)
X-Drupal-Cache: HIT
Content-Type: text/html; charset=UTF-8
```
- And then just to confirm it works as expected when the URI exists, go give it one
- `drush cr all`
- Re-visit the node and you should see the external URI in the link header with `rel="tag'`
```
ubuntu@claw:/var/www/html/drupal/web/modules/contrib/islandora/src$ curl -I localhost:8000/node/1
HTTP/1.1 200 OK
Date: Fri, 22 Jun 2018 02:49:37 GMT
Server: Apache/2.4.18 (Ubuntu)
X-Powered-By: PHP/7.0.30-0ubuntu0.16.04.1
Cache-Control: must-revalidate, no-cache, private
Link: <http://example.org/derp>; rel="tag"; title="Derp"
Link: <http://localhost:8000/node/1?_format=jsonld>; rel="alternate"; type="application/ld+json"
Link: <http://localhost:8000/node/1?_format=json>; rel="alternate"; type="application/json"
Link: </node/1>; rel="canonical"
Link: </node/1>; rel="shortlink"
Link: </node/1>; rel="revision"
Link: </node?node=1>; rel="create"
X-Drupal-Dynamic-Cache: MISS
X-UA-Compatible: IE=edge
Content-language: en
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
Expires: Sun, 19 Nov 1978 05:00:00 GMT
Vary: 
X-Generator: Drupal 8 (https://www.drupal.org)
X-Drupal-Cache: HIT
Content-Type: text/html; charset=UTF-8

```

# Additional Notes:
Thanks to @Natkeeran for reporting this one.

# Interested parties
@Islandora-CLAW/committers
