### PR TITLE
Removing unneccessary node_has_term condition

### DIFF
--- a/modules/islandora_demo_feature/config/install/context.context.repository_content.yml
+++ b/modules/islandora_demo_feature/config/install/context.context.repository_content.yml
@@ -22,10 +22,6 @@ conditions:
     uuid: 640d52cd-7cd5-4d9e-837d-c93b2deb814e
     context_mapping:
       node: '@node.node_route_context:node'
-  node_has_term:
-    id: node_has_term
-    negate: false
-    uuid: 4852a60d-06ef-4c8c-b983-98218db82111
 reactions:
   index:
     id: index


### PR DESCRIPTION
**GitHub Issue**: Resolves Islandora-CLAW/CLAW#853

# What does this Pull Request do?

Removes and unneccessary condition in the "All Repository Content" context, which was blocking form submission.

# What's new?

Less config.

# How should this be tested?

First, confirm the old behaviour:
- Make a new content type
- Go to the Context UI and edit the "All Repository Content" context.
- Try to select your new content type in the checkbox for 'Node Bundle'
- You should be prevented from submitting the form.

Then confirm the fix:
- Pull in this PR
- Re-import the `islandora_demo_feature` feature
- Go to the Context UI and edit the "All Repository Content" context.
- Try to select your new content type in the checkbox for 'Node Bundle'
- You should be allowed to submit the form now.

You'll notice that the "Node Has Term" condition is gone from the list.  It had a required field that was the culprit for blocking form submission.

# Interested parties
@Islandora-CLAW/committers here's an easy one to test and confirm thanks to features.
