### PR TITLE
make csv path relative

### DIFF
--- a/modules/islandora_core_feature/config/install/migrate_plus.migration.islandora_tags.yml
+++ b/modules/islandora_core_feature/config/install/migrate_plus.migration.islandora_tags.yml
@@ -13,7 +13,7 @@ migration_group: islandora
 label: 'Tags migration from CSV'
 source:
   plugin: csv
-  path: /var/www/html/drupal/web/modules/contrib/islandora/migrate/tags.csv
+  path: modules/contrib/islandora/migrate/tags.csv
   header_row_count: 1
   keys:
     - external_uri

--- a/modules/islandora_demo_feature/config/install/migrate_plus.migration.islandora_demo_tags.yml
+++ b/modules/islandora_demo_feature/config/install/migrate_plus.migration.islandora_demo_tags.yml
@@ -13,7 +13,7 @@ migration_group: islandora
 label: 'Tags migration for islandora_demo feature'
 source:
   plugin: csv
-  path: /var/www/html/drupal/web/modules/contrib/islandora/modules/islandora_demo_feature/migrate/tags.csv
+  path: modules/contrib/islandora/modules/islandora_demo_feature/migrate/tags.csv
   header_row_count: 1
   keys:
     - external_uri


### PR DESCRIPTION
**GitHub Issue**: Islandora-CLAW/CLAW/issues/861

# What does this Pull Request do?

Changes the migration config for tags.csv to use a relative path.

# What's new?

A relative path for tags.csv

# How should this be tested?

+ setup a new Drupal site; preferably one that doesn't use '/var/www/html/drupal/' which is part of the old hard-coded path. _Note: you don't need the whole CLAW to test this, just a vanilla Drupal works for the purposes of this test. I used a stock drupalvm site._
+ import the islandora core modules and feature
+ Run the islandora_tags migration
+ migration should run successfully with the new relative path.

# Interested parties
@Islandora-CLAW/committers