### PR TITLE
Don't translate mimetypes

### DIFF
--- a/islandora.info.yml
+++ b/islandora.info.yml
@@ -28,3 +28,4 @@ dependencies:
   - features_ui
   - migrate_tools
   - migrate_source_csv
+  - content_translation

--- a/modules/islandora_core_feature/config/install/core.base_field_override.media.audio.changed.yml
+++ b/modules/islandora_core_feature/config/install/core.base_field_override.media.audio.changed.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.audio
+id: media.audio.changed
+field_name: changed
+entity_type: media
+bundle: audio
+label: Changed
+description: 'The time the media item was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/modules/islandora_core_feature/config/install/core.base_field_override.media.audio.created.yml
+++ b/modules/islandora_core_feature/config/install/core.base_field_override.media.audio.created.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.audio
+id: media.audio.created
+field_name: created
+entity_type: media
+bundle: audio
+label: 'Authored on'
+description: 'The time the media item was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media\Entity\Media::getRequestTime'
+settings: {  }
+field_type: created

--- a/modules/islandora_core_feature/config/install/core.base_field_override.media.audio.path.yml
+++ b/modules/islandora_core_feature/config/install/core.base_field_override.media.audio.path.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.audio
+  module:
+    - path
+id: media.audio.path
+field_name: path
+entity_type: media
+bundle: audio
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/modules/islandora_core_feature/config/install/core.base_field_override.media.audio.status.yml
+++ b/modules/islandora_core_feature/config/install/core.base_field_override.media.audio.status.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.audio
+id: media.audio.status
+field_name: status
+entity_type: media
+bundle: audio
+label: Published
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/islandora_core_feature/config/install/core.base_field_override.media.audio.thumbnail.yml
+++ b/modules/islandora_core_feature/config/install/core.base_field_override.media.audio.thumbnail.yml
@@ -1,0 +1,36 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.audio
+  module:
+    - image
+id: media.audio.thumbnail
+field_name: thumbnail
+entity_type: media
+bundle: audio
+label: Thumbnail
+description: 'The thumbnail of the media item.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_extensions: 'png gif jpg jpeg'
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  max_resolution: ''
+  min_resolution: ''
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  max_filesize: ''
+  handler: default
+  handler_settings: {  }
+field_type: image

--- a/modules/islandora_core_feature/config/install/core.base_field_override.media.audio.uid.yml
+++ b/modules/islandora_core_feature/config/install/core.base_field_override.media.audio.uid.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.audio
+id: media.audio.uid
+field_name: uid
+entity_type: media
+bundle: audio
+label: 'Authored by'
+description: 'The user ID of the author.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media\Entity\Media::getCurrentUserId'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/modules/islandora_core_feature/config/install/core.base_field_override.media.file.changed.yml
+++ b/modules/islandora_core_feature/config/install/core.base_field_override.media.file.changed.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.file
+id: media.file.changed
+field_name: changed
+entity_type: media
+bundle: file
+label: Changed
+description: 'The time the media item was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/modules/islandora_core_feature/config/install/core.base_field_override.media.file.created.yml
+++ b/modules/islandora_core_feature/config/install/core.base_field_override.media.file.created.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.file
+id: media.file.created
+field_name: created
+entity_type: media
+bundle: file
+label: 'Authored on'
+description: 'The time the media item was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media\Entity\Media::getRequestTime'
+settings: {  }
+field_type: created

--- a/modules/islandora_core_feature/config/install/core.base_field_override.media.file.path.yml
+++ b/modules/islandora_core_feature/config/install/core.base_field_override.media.file.path.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.file
+  module:
+    - path
+id: media.file.path
+field_name: path
+entity_type: media
+bundle: file
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/modules/islandora_core_feature/config/install/core.base_field_override.media.file.status.yml
+++ b/modules/islandora_core_feature/config/install/core.base_field_override.media.file.status.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.file
+id: media.file.status
+field_name: status
+entity_type: media
+bundle: file
+label: Published
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/islandora_core_feature/config/install/core.base_field_override.media.file.thumbnail.yml
+++ b/modules/islandora_core_feature/config/install/core.base_field_override.media.file.thumbnail.yml
@@ -1,0 +1,36 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.file
+  module:
+    - image
+id: media.file.thumbnail
+field_name: thumbnail
+entity_type: media
+bundle: file
+label: Thumbnail
+description: 'The thumbnail of the media item.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_extensions: 'png gif jpg jpeg'
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  max_resolution: ''
+  min_resolution: ''
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  max_filesize: ''
+  handler: default
+  handler_settings: {  }
+field_type: image

--- a/modules/islandora_core_feature/config/install/core.base_field_override.media.file.uid.yml
+++ b/modules/islandora_core_feature/config/install/core.base_field_override.media.file.uid.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.file
+id: media.file.uid
+field_name: uid
+entity_type: media
+bundle: file
+label: 'Authored by'
+description: 'The user ID of the author.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media\Entity\Media::getCurrentUserId'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/modules/islandora_core_feature/config/install/core.base_field_override.media.image.changed.yml
+++ b/modules/islandora_core_feature/config/install/core.base_field_override.media.image.changed.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.image
+id: media.image.changed
+field_name: changed
+entity_type: media
+bundle: image
+label: Changed
+description: 'The time the media item was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/modules/islandora_core_feature/config/install/core.base_field_override.media.image.created.yml
+++ b/modules/islandora_core_feature/config/install/core.base_field_override.media.image.created.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.image
+id: media.image.created
+field_name: created
+entity_type: media
+bundle: image
+label: 'Authored on'
+description: 'The time the media item was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media\Entity\Media::getRequestTime'
+settings: {  }
+field_type: created

--- a/modules/islandora_core_feature/config/install/core.base_field_override.media.image.path.yml
+++ b/modules/islandora_core_feature/config/install/core.base_field_override.media.image.path.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.image
+  module:
+    - path
+id: media.image.path
+field_name: path
+entity_type: media
+bundle: image
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/modules/islandora_core_feature/config/install/core.base_field_override.media.image.status.yml
+++ b/modules/islandora_core_feature/config/install/core.base_field_override.media.image.status.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.image
+id: media.image.status
+field_name: status
+entity_type: media
+bundle: image
+label: Published
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/islandora_core_feature/config/install/core.base_field_override.media.image.thumbnail.yml
+++ b/modules/islandora_core_feature/config/install/core.base_field_override.media.image.thumbnail.yml
@@ -1,0 +1,36 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.image
+  module:
+    - image
+id: media.image.thumbnail
+field_name: thumbnail
+entity_type: media
+bundle: image
+label: Thumbnail
+description: 'The thumbnail of the media item.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_extensions: 'png gif jpg jpeg'
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  max_resolution: ''
+  min_resolution: ''
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  max_filesize: ''
+  handler: default
+  handler_settings: {  }
+field_type: image

--- a/modules/islandora_core_feature/config/install/core.base_field_override.media.image.uid.yml
+++ b/modules/islandora_core_feature/config/install/core.base_field_override.media.image.uid.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.image
+id: media.image.uid
+field_name: uid
+entity_type: media
+bundle: image
+label: 'Authored by'
+description: 'The user ID of the author.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media\Entity\Media::getCurrentUserId'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/modules/islandora_core_feature/config/install/core.base_field_override.media.video.changed.yml
+++ b/modules/islandora_core_feature/config/install/core.base_field_override.media.video.changed.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.video
+id: media.video.changed
+field_name: changed
+entity_type: media
+bundle: video
+label: Changed
+description: 'The time the media item was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/modules/islandora_core_feature/config/install/core.base_field_override.media.video.created.yml
+++ b/modules/islandora_core_feature/config/install/core.base_field_override.media.video.created.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.video
+id: media.video.created
+field_name: created
+entity_type: media
+bundle: video
+label: 'Authored on'
+description: 'The time the media item was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media\Entity\Media::getRequestTime'
+settings: {  }
+field_type: created

--- a/modules/islandora_core_feature/config/install/core.base_field_override.media.video.path.yml
+++ b/modules/islandora_core_feature/config/install/core.base_field_override.media.video.path.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.video
+  module:
+    - path
+id: media.video.path
+field_name: path
+entity_type: media
+bundle: video
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/modules/islandora_core_feature/config/install/core.base_field_override.media.video.status.yml
+++ b/modules/islandora_core_feature/config/install/core.base_field_override.media.video.status.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.video
+id: media.video.status
+field_name: status
+entity_type: media
+bundle: video
+label: Published
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/islandora_core_feature/config/install/core.base_field_override.media.video.thumbnail.yml
+++ b/modules/islandora_core_feature/config/install/core.base_field_override.media.video.thumbnail.yml
@@ -1,0 +1,36 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.video
+  module:
+    - image
+id: media.video.thumbnail
+field_name: thumbnail
+entity_type: media
+bundle: video
+label: Thumbnail
+description: 'The thumbnail of the media item.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_extensions: 'png gif jpg jpeg'
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  max_resolution: ''
+  min_resolution: ''
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  max_filesize: ''
+  handler: default
+  handler_settings: {  }
+field_type: image

--- a/modules/islandora_core_feature/config/install/core.base_field_override.media.video.uid.yml
+++ b/modules/islandora_core_feature/config/install/core.base_field_override.media.video.uid.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.video
+id: media.video.uid
+field_name: uid
+entity_type: media
+bundle: video
+label: 'Authored by'
+description: 'The user ID of the author.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media\Entity\Media::getCurrentUserId'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/modules/islandora_core_feature/config/install/core.base_field_override.taxonomy_term.tags.changed.yml
+++ b/modules/islandora_core_feature/config/install/core.base_field_override.taxonomy_term.tags.changed.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.tags
+id: taxonomy_term.tags.changed
+field_name: changed
+entity_type: taxonomy_term
+bundle: tags
+label: Changed
+description: 'The time that the term was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/modules/islandora_core_feature/config/install/core.base_field_override.taxonomy_term.tags.description.yml
+++ b/modules/islandora_core_feature/config/install/core.base_field_override.taxonomy_term.tags.description.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.tags
+  module:
+    - text
+id: taxonomy_term.tags.description
+field_name: description
+entity_type: taxonomy_term
+bundle: tags
+label: Description
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/modules/islandora_core_feature/config/install/core.base_field_override.taxonomy_term.tags.name.yml
+++ b/modules/islandora_core_feature/config/install/core.base_field_override.taxonomy_term.tags.name.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.tags
+id: taxonomy_term.tags.name
+field_name: name
+entity_type: taxonomy_term
+bundle: tags
+label: Name
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/islandora_core_feature/config/install/core.base_field_override.taxonomy_term.tags.path.yml
+++ b/modules/islandora_core_feature/config/install/core.base_field_override.taxonomy_term.tags.path.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.tags
+  module:
+    - path
+id: taxonomy_term.tags.path
+field_name: path
+entity_type: taxonomy_term
+bundle: tags
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/modules/islandora_core_feature/config/install/core.entity_view_display.media.audio.source.yml
+++ b/modules/islandora_core_feature/config/install/core.entity_view_display.media.audio.source.yml
@@ -36,6 +36,7 @@ hidden:
   field_media_of: true
   field_mime_type: true
   field_tags: true
+  langcode: true
   name: true
   thumbnail: true
   uid: true

--- a/modules/islandora_core_feature/config/install/core.entity_view_display.media.file.source.yml
+++ b/modules/islandora_core_feature/config/install/core.entity_view_display.media.file.source.yml
@@ -33,6 +33,7 @@ hidden:
   field_media_of: true
   field_mime_type: true
   field_tags: true
+  langcode: true
   name: true
   thumbnail: true
   uid: true

--- a/modules/islandora_core_feature/config/install/core.entity_view_display.media.image.source.yml
+++ b/modules/islandora_core_feature/config/install/core.entity_view_display.media.image.source.yml
@@ -38,6 +38,7 @@ hidden:
   field_mime_type: true
   field_tags: true
   field_width: true
+  langcode: true
   name: true
   thumbnail: true
   uid: true

--- a/modules/islandora_core_feature/config/install/core.entity_view_display.media.video.source.yml
+++ b/modules/islandora_core_feature/config/install/core.entity_view_display.media.video.source.yml
@@ -39,6 +39,7 @@ hidden:
   field_media_of: true
   field_mime_type: true
   field_tags: true
+  langcode: true
   name: true
   thumbnail: true
   uid: true

--- a/modules/islandora_core_feature/config/install/core.entity_view_display.node.article.default.yml
+++ b/modules/islandora_core_feature/config/install/core.entity_view_display.node.article.default.yml
@@ -1,0 +1,61 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_display.comment.comment.default
+    - field.field.node.article.body
+    - field.field.node.article.comment
+    - field.field.node.article.field_image
+    - field.field.node.article.field_tags
+    - image.style.large
+    - node.type.article
+  module:
+    - comment
+    - image
+    - text
+    - user
+id: node.article.default
+targetEntityType: node
+bundle: article
+mode: default
+content:
+  body:
+    type: text_default
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+    label: hidden
+  comment:
+    type: comment_default
+    weight: 110
+    region: content
+    label: above
+    settings:
+      view_mode: default
+      pager_id: 0
+    third_party_settings: {  }
+  field_image:
+    type: image
+    weight: -1
+    region: content
+    settings:
+      image_style: large
+      image_link: ''
+    third_party_settings: {  }
+    label: hidden
+  field_tags:
+    type: entity_reference_label
+    weight: 10
+    region: content
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+  links:
+    weight: 100
+    region: content
+hidden:
+  field_image: true
+  field_tags: true
+  langcode: true

--- a/modules/islandora_core_feature/config/install/core.entity_view_display.node.article.rss.yml
+++ b/modules/islandora_core_feature/config/install/core.entity_view_display.node.article.rss.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.rss
+    - field.field.node.article.body
+    - field.field.node.article.comment
+    - field.field.node.article.field_image
+    - field.field.node.article.field_tags
+    - node.type.article
+  module:
+    - user
+id: node.article.rss
+targetEntityType: node
+bundle: article
+mode: rss
+content:
+  links:
+    weight: 100
+    region: content
+hidden:
+  body: true
+  comment: true
+  field_image: true
+  field_tags: true
+  langcode: true

--- a/modules/islandora_core_feature/config/install/core.entity_view_display.node.article.teaser.yml
+++ b/modules/islandora_core_feature/config/install/core.entity_view_display.node.article.teaser.yml
@@ -1,0 +1,53 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.article.body
+    - field.field.node.article.comment
+    - field.field.node.article.field_image
+    - field.field.node.article.field_tags
+    - image.style.medium
+    - node.type.article
+  module:
+    - image
+    - text
+    - user
+id: node.article.teaser
+targetEntityType: node
+bundle: article
+mode: teaser
+content:
+  body:
+    type: text_summary_or_trimmed
+    weight: 0
+    region: content
+    settings:
+      trim_length: 600
+    third_party_settings: {  }
+    label: hidden
+  field_image:
+    type: image
+    weight: -1
+    region: content
+    settings:
+      image_style: medium
+      image_link: content
+    third_party_settings: {  }
+    label: hidden
+  field_tags:
+    type: entity_reference_label
+    weight: 10
+    region: content
+    settings:
+      link: true
+    third_party_settings: {  }
+    label: above
+  links:
+    weight: 100
+    region: content
+hidden:
+  comment: true
+  field_image: true
+  field_tags: true
+  langcode: true

--- a/modules/islandora_core_feature/config/install/field.field.media.audio.field_file_size.yml
+++ b/modules/islandora_core_feature/config/install/field.field.media.audio.field_file_size.yml
@@ -14,7 +14,7 @@ bundle: audio
 label: 'File size'
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/islandora_core_feature/config/install/field.field.media.audio.field_media_audio_file.yml
+++ b/modules/islandora_core_feature/config/install/field.field.media.audio.field_media_audio_file.yml
@@ -16,7 +16,7 @@ bundle: audio
 label: 'Audio file'
 description: ''
 required: true
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/islandora_core_feature/config/install/field.field.media.audio.field_mime_type.yml
+++ b/modules/islandora_core_feature/config/install/field.field.media.audio.field_mime_type.yml
@@ -14,7 +14,7 @@ bundle: audio
 label: 'MIME type'
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/islandora_core_feature/config/install/field.field.media.file.field_media_file.yml
+++ b/modules/islandora_core_feature/config/install/field.field.media.file.field_media_file.yml
@@ -17,7 +17,7 @@ bundle: file
 label: File
 description: ''
 required: true
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/islandora_core_feature/config/install/field.field.media.file.field_media_of.yml
+++ b/modules/islandora_core_feature/config/install/field.field.media.file.field_media_of.yml
@@ -14,7 +14,7 @@ bundle: file
 label: 'Media of'
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/islandora_core_feature/config/install/field.field.media.file.field_tags.yml
+++ b/modules/islandora_core_feature/config/install/field.field.media.file.field_tags.yml
@@ -14,7 +14,7 @@ bundle: file
 label: Tags
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/islandora_core_feature/config/install/field.field.media.image.field_file_size.yml
+++ b/modules/islandora_core_feature/config/install/field.field.media.image.field_file_size.yml
@@ -14,7 +14,7 @@ bundle: image
 label: 'File size'
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/islandora_core_feature/config/install/field.field.media.image.field_media_image.yml
+++ b/modules/islandora_core_feature/config/install/field.field.media.image.field_media_image.yml
@@ -17,7 +17,7 @@ bundle: image
 label: Image
 description: ''
 required: true
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/islandora_core_feature/config/install/field.field.media.image.field_media_of.yml
+++ b/modules/islandora_core_feature/config/install/field.field.media.image.field_media_of.yml
@@ -14,7 +14,7 @@ bundle: image
 label: 'Media of'
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/islandora_core_feature/config/install/field.field.media.image.field_mime_type.yml
+++ b/modules/islandora_core_feature/config/install/field.field.media.image.field_mime_type.yml
@@ -14,7 +14,7 @@ bundle: image
 label: 'MIME type'
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/islandora_core_feature/config/install/field.field.media.image.field_tags.yml
+++ b/modules/islandora_core_feature/config/install/field.field.media.image.field_tags.yml
@@ -14,7 +14,7 @@ bundle: image
 label: Tags
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/islandora_core_feature/config/install/field.field.media.video.field_file_size.yml
+++ b/modules/islandora_core_feature/config/install/field.field.media.video.field_file_size.yml
@@ -14,7 +14,7 @@ bundle: video
 label: 'File size'
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/islandora_core_feature/config/install/field.field.media.video.field_media_of.yml
+++ b/modules/islandora_core_feature/config/install/field.field.media.video.field_media_of.yml
@@ -14,7 +14,7 @@ bundle: video
 label: 'Media of'
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/islandora_core_feature/config/install/field.field.media.video.field_media_video_file.yml
+++ b/modules/islandora_core_feature/config/install/field.field.media.video.field_media_video_file.yml
@@ -16,7 +16,7 @@ bundle: video
 label: 'Video file'
 description: ''
 required: true
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/islandora_core_feature/config/install/field.field.media.video.field_mime_type.yml
+++ b/modules/islandora_core_feature/config/install/field.field.media.video.field_mime_type.yml
@@ -14,7 +14,7 @@ bundle: video
 label: 'MIME type'
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/islandora_core_feature/config/install/field.field.media.video.field_tags.yml
+++ b/modules/islandora_core_feature/config/install/field.field.media.video.field_tags.yml
@@ -14,7 +14,7 @@ bundle: video
 label: Tags
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/islandora_core_feature/config/install/field.field.node.article.field_tags.yml
+++ b/modules/islandora_core_feature/config/install/field.field.node.article.field_tags.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_tags
+    - node.type.article
+    - taxonomy.vocabulary.tags
+id: node.article.field_tags
+field_name: field_tags
+entity_type: node
+bundle: article
+label: Tags
+description: 'Enter a comma-separated list. For example: Amsterdam, Mexico City, "Cleveland, Ohio"'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      tags: tags
+    sort:
+      field: _none
+    auto_create: true
+field_type: entity_reference

--- a/modules/islandora_core_feature/config/install/field.storage.media.field_mime_type.yml
+++ b/modules/islandora_core_feature/config/install/field.storage.media.field_mime_type.yml
@@ -17,7 +17,7 @@ settings:
 module: core
 locked: false
 cardinality: 1
-translatable: true
+translatable: false
 indexes: {  }
 persist_with_no_fields: false
 custom_storage: false

--- a/modules/islandora_core_feature/config/install/language.content_settings.media.audio.yml
+++ b/modules/islandora_core_feature/config/install/language.content_settings.media.audio.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.audio
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: media.audio
+target_entity_type_id: media
+target_bundle: audio
+default_langcode: site_default
+language_alterable: true

--- a/modules/islandora_core_feature/config/install/language.content_settings.media.file.yml
+++ b/modules/islandora_core_feature/config/install/language.content_settings.media.file.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.file
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: media.file
+target_entity_type_id: media
+target_bundle: file
+default_langcode: site_default
+language_alterable: true

--- a/modules/islandora_core_feature/config/install/language.content_settings.media.image.yml
+++ b/modules/islandora_core_feature/config/install/language.content_settings.media.image.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.image
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: media.image
+target_entity_type_id: media
+target_bundle: image
+default_langcode: site_default
+language_alterable: true

--- a/modules/islandora_core_feature/config/install/language.content_settings.media.video.yml
+++ b/modules/islandora_core_feature/config/install/language.content_settings.media.video.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.video
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: media.video
+target_entity_type_id: media
+target_bundle: video
+default_langcode: site_default
+language_alterable: true

--- a/modules/islandora_core_feature/config/install/language.content_settings.taxonomy_term.tags.yml
+++ b/modules/islandora_core_feature/config/install/language.content_settings.taxonomy_term.tags.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.tags
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: taxonomy_term.tags
+target_entity_type_id: taxonomy_term
+target_bundle: tags
+default_langcode: site_default
+language_alterable: false

--- a/modules/islandora_core_feature/islandora_core_feature.info.yml
+++ b/modules/islandora_core_feature/islandora_core_feature.info.yml
@@ -4,23 +4,29 @@ type: module
 core: 8.x
 dependencies:
   - basic_auth
+  - comment
+  - content_translation
   - eva
   - features
   - field
   - file
   - image
   - islandora
+  - islandora_demo_feature
   - jsonld
   - jwt
+  - language
   - link
   - media
   - migrate_plus
   - node
+  - path
   - rdf
   - rest
   - serialization
   - system
   - taxonomy
+  - text
   - user
   - views
 package: Islandora

--- a/modules/islandora_demo_feature/config/install/core.base_field_override.node.islandora_object.changed.yml
+++ b/modules/islandora_demo_feature/config/install/core.base_field_override.node.islandora_object.changed.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.islandora_object
+id: node.islandora_object.changed
+field_name: changed
+entity_type: node
+bundle: islandora_object
+label: Changed
+description: 'The time that the node was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/modules/islandora_demo_feature/config/install/core.base_field_override.node.islandora_object.created.yml
+++ b/modules/islandora_demo_feature/config/install/core.base_field_override.node.islandora_object.created.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.islandora_object
+id: node.islandora_object.created
+field_name: created
+entity_type: node
+bundle: islandora_object
+label: 'Authored on'
+description: 'The time that the node was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/modules/islandora_demo_feature/config/install/core.base_field_override.node.islandora_object.path.yml
+++ b/modules/islandora_demo_feature/config/install/core.base_field_override.node.islandora_object.path.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.islandora_object
+  module:
+    - path
+id: node.islandora_object.path
+field_name: path
+entity_type: node
+bundle: islandora_object
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/modules/islandora_demo_feature/config/install/core.base_field_override.node.islandora_object.promote.yml
+++ b/modules/islandora_demo_feature/config/install/core.base_field_override.node.islandora_object.promote.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.islandora_object
+id: node.islandora_object.promote
+field_name: promote
+entity_type: node
+bundle: islandora_object
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/islandora_demo_feature/config/install/core.base_field_override.node.islandora_object.status.yml
+++ b/modules/islandora_demo_feature/config/install/core.base_field_override.node.islandora_object.status.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.islandora_object
+id: node.islandora_object.status
+field_name: status
+entity_type: node
+bundle: islandora_object
+label: Published
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/islandora_demo_feature/config/install/core.base_field_override.node.islandora_object.sticky.yml
+++ b/modules/islandora_demo_feature/config/install/core.base_field_override.node.islandora_object.sticky.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.islandora_object
+id: node.islandora_object.sticky
+field_name: sticky
+entity_type: node
+bundle: islandora_object
+label: 'Sticky at top of lists'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/islandora_demo_feature/config/install/core.base_field_override.node.islandora_object.uid.yml
+++ b/modules/islandora_demo_feature/config/install/core.base_field_override.node.islandora_object.uid.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.islandora_object
+id: node.islandora_object.uid
+field_name: uid
+entity_type: node
+bundle: islandora_object
+label: 'Authored by'
+description: 'The username of the content author.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\node\Entity\Node::getCurrentUserId'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/modules/islandora_demo_feature/config/install/core.entity_form_display.media.audio.default.yml
+++ b/modules/islandora_demo_feature/config/install/core.entity_form_display.media.audio.default.yml
@@ -47,6 +47,13 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
   name:
     type: string_textfield
     weight: 0

--- a/modules/islandora_demo_feature/config/install/core.entity_form_display.media.file.default.yml
+++ b/modules/islandora_demo_feature/config/install/core.entity_form_display.media.file.default.yml
@@ -47,6 +47,13 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
   name:
     type: string_textfield
     weight: 0

--- a/modules/islandora_demo_feature/config/install/core.entity_form_display.media.image.default.yml
+++ b/modules/islandora_demo_feature/config/install/core.entity_form_display.media.image.default.yml
@@ -51,6 +51,13 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
   name:
     type: string_textfield
     weight: 0

--- a/modules/islandora_demo_feature/config/install/core.entity_form_display.media.video.default.yml
+++ b/modules/islandora_demo_feature/config/install/core.entity_form_display.media.video.default.yml
@@ -47,6 +47,13 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
   name:
     type: string_textfield
     weight: 0

--- a/modules/islandora_demo_feature/config/install/core.entity_form_display.node.article.default.yml
+++ b/modules/islandora_demo_feature/config/install/core.entity_form_display.node.article.default.yml
@@ -56,6 +56,13 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
   path:
     type: path
     weight: 30

--- a/modules/islandora_demo_feature/config/install/core.entity_form_display.node.islandora_object.default.yml
+++ b/modules/islandora_demo_feature/config/install/core.entity_form_display.node.islandora_object.default.yml
@@ -48,6 +48,13 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
   path:
     type: path
     weight: 8

--- a/modules/islandora_demo_feature/config/install/core.entity_form_display.taxonomy_term.tags.default.yml
+++ b/modules/islandora_demo_feature/config/install/core.entity_form_display.taxonomy_term.tags.default.yml
@@ -29,6 +29,13 @@ content:
     third_party_settings: {  }
     type: link_default
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
   name:
     type: string_textfield
     weight: 0

--- a/modules/islandora_demo_feature/config/install/core.entity_view_display.media.audio.default.yml
+++ b/modules/islandora_demo_feature/config/install/core.entity_view_display.media.audio.default.yml
@@ -69,5 +69,6 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  langcode: true
   thumbnail: true
   uid: true

--- a/modules/islandora_demo_feature/config/install/core.entity_view_display.media.file.default.yml
+++ b/modules/islandora_demo_feature/config/install/core.entity_view_display.media.file.default.yml
@@ -66,5 +66,6 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  langcode: true
   thumbnail: true
   uid: true

--- a/modules/islandora_demo_feature/config/install/core.entity_view_display.media.file.open_seadragon.yml
+++ b/modules/islandora_demo_feature/config/install/core.entity_view_display.media.file.open_seadragon.yml
@@ -32,6 +32,7 @@ hidden:
   field_media_of: true
   field_mime_type: true
   field_tags: true
+  langcode: true
   name: true
   thumbnail: true
   uid: true

--- a/modules/islandora_demo_feature/config/install/core.entity_view_display.media.image.default.yml
+++ b/modules/islandora_demo_feature/config/install/core.entity_view_display.media.image.default.yml
@@ -87,5 +87,6 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  langcode: true
   thumbnail: true
   uid: true

--- a/modules/islandora_demo_feature/config/install/core.entity_view_display.media.image.open_seadragon.yml
+++ b/modules/islandora_demo_feature/config/install/core.entity_view_display.media.image.open_seadragon.yml
@@ -36,6 +36,7 @@ hidden:
   field_mime_type: true
   field_tags: true
   field_width: true
+  langcode: true
   name: true
   thumbnail: true
   uid: true

--- a/modules/islandora_demo_feature/config/install/core.entity_view_display.media.video.default.yml
+++ b/modules/islandora_demo_feature/config/install/core.entity_view_display.media.video.default.yml
@@ -72,5 +72,6 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  langcode: true
   thumbnail: true
   uid: true

--- a/modules/islandora_demo_feature/config/install/core.entity_view_display.node.islandora_object.binary.yml
+++ b/modules/islandora_demo_feature/config/install/core.entity_view_display.node.islandora_object.binary.yml
@@ -59,5 +59,6 @@ hidden:
   display_media_entity_view_2: true
   display_media_service_file: true
   display_media_thumbnail: true
+  langcode: true
   openseadragon_media_evas_entity_view_2: true
   openseadragon_media_evas_service_file: true

--- a/modules/islandora_demo_feature/config/install/core.entity_view_display.node.islandora_object.default.yml
+++ b/modules/islandora_demo_feature/config/install/core.entity_view_display.node.islandora_object.default.yml
@@ -58,5 +58,6 @@ hidden:
   display_media_entity_view_1: true
   display_media_entity_view_2: true
   display_media_thumbnail: true
+  langcode: true
   openseadragon_media_evas_entity_view_2: true
   openseadragon_media_evas_service_file: true

--- a/modules/islandora_demo_feature/config/install/core.entity_view_display.node.islandora_object.open_seadragon.yml
+++ b/modules/islandora_demo_feature/config/install/core.entity_view_display.node.islandora_object.open_seadragon.yml
@@ -59,4 +59,5 @@ hidden:
   display_media_entity_view_1: true
   display_media_service_file: true
   display_media_thumbnail: true
+  langcode: true
   openseadragon_media_evas_service_file: true

--- a/modules/islandora_demo_feature/config/install/core.entity_view_display.node.islandora_object.teaser.yml
+++ b/modules/islandora_demo_feature/config/install/core.entity_view_display.node.islandora_object.teaser.yml
@@ -34,6 +34,7 @@ hidden:
   field_description: true
   field_member_of: true
   field_tags: true
+  langcode: true
   members_eva_entity_view_1: true
   openseadragon_media_evas_entity_view_2: true
   openseadragon_media_evas_service_file: true

--- a/modules/islandora_demo_feature/config/install/core.entity_view_display.taxonomy_term.tags.default.yml
+++ b/modules/islandora_demo_feature/config/install/core.entity_view_display.taxonomy_term.tags.default.yml
@@ -31,4 +31,5 @@ content:
     third_party_settings: {  }
     type: link
     region: content
-hidden: {  }
+hidden:
+  langcode: true

--- a/modules/islandora_demo_feature/config/install/field.field.node.islandora_object.field_tags.yml
+++ b/modules/islandora_demo_feature/config/install/field.field.node.islandora_object.field_tags.yml
@@ -14,7 +14,7 @@ bundle: islandora_object
 label: Tags
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/islandora_demo_feature/config/install/language.content_settings.node.islandora_object.yml
+++ b/modules/islandora_demo_feature/config/install/language.content_settings.node.islandora_object.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.islandora_object
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: node.islandora_object
+target_entity_type_id: node
+target_bundle: islandora_object
+default_langcode: site_default
+language_alterable: true

--- a/modules/islandora_demo_feature/islandora_demo_feature.features.yml
+++ b/modules/islandora_demo_feature/islandora_demo_feature.features.yml
@@ -5,8 +5,6 @@ excluded:
   - field.field.node.article.field_image
   - core.entity_view_display.node.article.default
   - core.entity_view_display.node.article.rss
-  - core.entity_view_display.node.article.search_index
-  - core.entity_view_display.node.article.search_result
   - core.entity_view_display.node.article.teaser
   - core.entity_view_display.node.page.teaser
   - views.view.archive

--- a/modules/islandora_demo_feature/islandora_demo_feature.info.yml
+++ b/modules/islandora_demo_feature/islandora_demo_feature.info.yml
@@ -4,6 +4,7 @@ type: module
 core: 8.x
 dependencies:
   - comment
+  - content_translation
   - context
   - eva
   - field
@@ -12,6 +13,7 @@ dependencies:
   - islandora
   - islandora_core_feature
   - islandora_image
+  - language
   - link
   - media
   - menu_ui


### PR DESCRIPTION
**GitHub Issue**: Resolves Islandora-CLAW/CLAW#840

# What does this Pull Request do?

By setting up content translation on your site, fields indicated as non-translatable will no longer get language tags applied to them by `jsonld`.  Big @DiegoPino++ on this one.  No code changes neccessary, just config!

Now we can pull our derivatives out of Fedora again!

# What's new?
A bunch of exported config into our features
* Content translation settings
* Field settings
* Some field overrides

# How should this be tested?

- Make a Media
- Check out its jsonld, the mimetpe property should have a lang of '@en'
```json
{

         "http:\/\/www.ebu.ch\/metadata\/ontologies\/ebucore\/ebucore#hasMimeType":[
            {
               "@value":"image\/gif",
               "@language":"en"
            }
         ],
```
- Enable the core `content_translation` module
- Pull in these changes
- Import both features
- Go check out the jsonld again, this time mimetype should be explictly labeled as an `xsd:string` and should not have any languages applied to it
```json
         "http:\/\/www.ebu.ch\/metadata\/ontologies\/ebucore\/ebucore#hasMimeType":[
            {
               "@value":"image\/gif",
               "@type":"http:\/\/www.w3.org\/2001\/XMLSchema#string"
            }
         ],
```

# Interested parties
Here's an easy one @Islandora-CLAW/committers
