### PR TITLE
Catching exceptions when generating events to get published on the queue

### DIFF
--- a/src/EventGenerator/EmitEvent.php
+++ b/src/EventGenerator/EmitEvent.php
@@ -127,12 +127,25 @@ abstract class EmitEvent extends ConfigurableActionBase implements ContainerFact
     }
 
     // Generate event as stomp message.
-    $user = $this->entityTypeManager->getStorage('user')->load($this->account->id());
-    $data = $this->generateData($entity);
-    $message = new Message(
-      $this->eventGenerator->generateEvent($entity, $user, $data),
-      ['Authorization' => "Bearer $token"]
-    );
+    try {
+      $user = $this->entityTypeManager->getStorage('user')->load($this->account->id());
+      $data = $this->generateData($entity);
+      $message = new Message(
+        $this->eventGenerator->generateEvent($entity, $user, $data),
+        ['Authorization' => "Bearer $token"]
+      );
+    }
+    catch (\RuntimeException $e) {
+      // Notify the user the event couldn't be generated and abort.
+      \Drupal::logger('islandora')->error(
+        t('Error generating event: @msg', ['@msg' => $e->getMessage()])
+      );
+      drupal_set_message(
+        t('Error generating event: @msg', ['@msg' => $e->getMessage()]),
+        'error'
+      );
+      return;
+    }
 
     // Send the message.
     try {


### PR DESCRIPTION
**GitHub Issue**: Islandora-CLAW/CLAW#846

* Islandora-CLAW/islandora_image#25

# What does this Pull Request do?

Catches exceptions when generating events so there's no more WSODing.

# What's new?
A try/catch block with some logging and dsm'ing.

# How should this be tested?

Pull in this code.  Pull in Islandora-CLAW/islandora_image#25.  Clear your cache.  Try to generate an image derivative from a source that does not exist (e.g. you have no preservation master, and request a source file). You should get a dsm and a log entry that have the exception message in it. No WSOD.

# Interested parties
Easy one to test @manez @Islandora-CLAW/committers
