### PR TITLE
Delete tombstone if it exists

### DIFF
--- a/src/Flysystem/Adapter/FedoraAdapter.php
+++ b/src/Flysystem/Adapter/FedoraAdapter.php
@@ -283,8 +283,14 @@ class FedoraAdapter implements AdapterInterface {
    */
   public function delete($path) {
     $response = $this->fedora->deleteResource($path);
-
     $code = $response->getStatusCode();
+    if ($code == 204) {
+      // Deleted so check for a tombstone as well.
+      $tomb_code = $this->deleteTombstone($path);
+      if (!is_null($tomb_code)) {
+        return $tomb_code;
+      }
+    }
     return in_array($code, [204, 404]);
   }
 
@@ -319,6 +325,38 @@ class FedoraAdapter implements AdapterInterface {
     }
 
     return $this->getMetadata($dirname);
+  }
+
+  /**
+   * Delete a tombstone for a path if it exists.
+   *
+   * @param $path
+   *   The original deleted resource path.
+   *
+   * @return bool|null
+   *   NULL if no tombstone, TRUE if tombstone deleted, FALSE otherwise.
+   */
+  private function deleteTombstone($path) {
+    $response = $this->fedora->getResourceHeaders($path);
+    $return = NULL;
+    if ($response->getStatusCode() == 410) {
+      $return = FALSE;
+      $link_headers = Psr7\parse_header($response->getHeader('Link'));
+      if ($link_headers) {
+        $tombstones = array_filter($link_headers, function ($o) {
+          return (isset($o['rel']) && $o['rel'] == 'hasTombstone');
+        });
+        foreach ($tombstones as $tombstone) {
+          // Trim <> from URL.
+          $url = rtrim(ltrim($tombstone[0], '<'),'>');
+          $response = $this->fedora->deleteResource($url);
+          if ($response->getStatusCode() == 204) {
+            $return = TRUE;
+          }
+        }
+      }
+    }
+    return $return;
   }
 
 }

--- a/src/Flysystem/Adapter/FedoraAdapter.php
+++ b/src/Flysystem/Adapter/FedoraAdapter.php
@@ -330,7 +330,7 @@ class FedoraAdapter implements AdapterInterface {
   /**
    * Delete a tombstone for a path if it exists.
    *
-   * @param $path
+   * @param string $path
    *   The original deleted resource path.
    *
    * @return bool|null
@@ -348,7 +348,7 @@ class FedoraAdapter implements AdapterInterface {
         });
         foreach ($tombstones as $tombstone) {
           // Trim <> from URL.
-          $url = rtrim(ltrim($tombstone[0], '<'),'>');
+          $url = rtrim(ltrim($tombstone[0], '<'), '>');
           $response = $this->fedora->deleteResource($url);
           if ($response->getStatusCode() == 204) {
             $return = TRUE;


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/908

# What does this Pull Request do?

After a delete it does a `HEAD` to the URL and if it gets a `410 Gone` response, it checks for a `Link` header with a `rel="hasTombstone"`.

It then tries to delete that tombstone.

This is very Fedora Community Implementation specific. But should not impact alternate implementations.

# What's new?

* Does this change require documentation to be updated? maybe
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?

Before this PR files were created as entities in the database even if they weren't persisted to Fedora.
You could
1. go to Add Media
1. Upload a file
1. In another tab check the Drupal Content -> Files and see the file.
1. In another tab check Fedora and see the file.
1. Remove the Media from the original "Add media" page.
1. See the file disappear from the Content -> Files page
1. See a tombstone message in Fedora.

After this PR the only thing different is the last step. 

Instead of the tombstone message you get a 404

# Additional Notes:

# Interested parties
@Islandora-CLAW/committers
