### PR TITLE
Fixes core block placement: Issue 931

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,6 @@ install:
   - cd web; drush --uri=127.0.0.1:8282 en -y islandora
 
 script:
-  - echo "Travis build directory"
-  - echo $TRAVIS_BUILD_DIR
   - $SCRIPT_DIR/line_endings.sh $TRAVIS_BUILD_DIR
   - phpcs --standard=Drupal --ignore=*.md --extensions=php,module,inc,install,test,profile,theme,css,info $TRAVIS_BUILD_DIR
   - phpcpd --names *.module,*.inc,*.test,*.php $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ install:
   - cd web; drush --uri=127.0.0.1:8282 en -y islandora
 
 script:
+  - echo "Travis build directory"
+  - echo $TRAVIS_BUILD_DIR
   - $SCRIPT_DIR/line_endings.sh $TRAVIS_BUILD_DIR
   - phpcs --standard=Drupal --ignore=*.md --extensions=php,module,inc,install,test,profile,theme,css,info $TRAVIS_BUILD_DIR
   - phpcpd --names *.module,*.inc,*.test,*.php $TRAVIS_BUILD_DIR

--- a/islandora.module
+++ b/islandora.module
@@ -15,6 +15,7 @@
  */
 
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\NodeInterface;
 use Drupal\media\MediaInterface;
 use Drupal\file\FileInterface;
@@ -321,4 +322,18 @@ function islandora_entity_form_display_alter(&$form_display, $context) {
       \Drupal::logger('islandora')->info("EntityFormDisplay $machine_name does not exist.  Form display cannot be altered.");
     }
   }
+}
+
+function islandora_form_block_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Unset our custom conditions.  There's too many to use well within
+  // the core block placement UI, and no other reasonable way to filter
+  // them out.  See https://www.drupal.org/node/2284687.  Use 
+  // /admin/structure/context instead if you want to use these conditions
+  // to alter block layout.
+  unset($form['visibility']['content_entity_type']);
+  unset($form['visibility']['parent_node_has_term']);
+  unset($form['visibility']['media_has_term']);
+  unset($form['visibility']['file_uses_filesystem']);
+  unset($form['visibility']['node_has_term']);
+  unset($form['visibility']['media_uses_filesystem']);
 }

--- a/islandora.module
+++ b/islandora.module
@@ -324,10 +324,13 @@ function islandora_entity_form_display_alter(&$form_display, $context) {
   }
 }
 
+/**
+ * Implements hook_form_form_id_alter().
+ */
 function islandora_form_block_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   // Unset our custom conditions.  There's too many to use well within
   // the core block placement UI, and no other reasonable way to filter
-  // them out.  See https://www.drupal.org/node/2284687.  Use 
+  // them out.  See https://www.drupal.org/node/2284687.  Use
   // /admin/structure/context instead if you want to use these conditions
   // to alter block layout.
   unset($form['visibility']['content_entity_type']);


### PR DESCRIPTION
**GitHub Issue**: Resolves Islandora-CLAW/CLAW#931 in the sense core block placement is no longer busted.  

But deeper issues remain w/r/t the core block placement ui.  See https://www.drupal.org/node/2284687

# What does this Pull Request do?

Alters our custom `Condition` plugins out of the core block placement UI.  They shouldn't be there and are breaking core block placement.  This puts it back to the way a vanilla D8 would look.

If you want to do sophisticated block placement by arbitrary criteria, you'll need to use the Context UI at `/admin/structure/context`.

# What's new?
A `form_alter` and some `unset`s.

# How should this be tested?

- Reproduce bug as per Islandora-CLAW/CLAW#931
- Pull down this code
- `drush cr`
- Go place a new block in Sidebar Second and see it appears.  Core block placement should be back to normal.
 
# Interested parties
@Islandora-CLAW/committers @MarcusBarnes 
