### PR TITLE
only change view mode for the current node

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -257,23 +257,30 @@ function islandora_entity_view_mode_alter(&$view_mode, EntityInterface $entity) 
   // ContextReaction.
   $storage = \Drupal::service('entity_type.manager')->getStorage('entity_view_mode');
   $context_manager = \Drupal::service('context.manager');
+  $current_entity = \Drupal::routeMatch()->getParameter('node');
+  $current_id = NULL;
+  if ($current_entity instanceof \Drupal\node\NodeInterface) {
+    $current_id = $current_entity->id();
+  }
+  if (isset($current_id) && $current_id == $entity->id()) {
+    foreach ($context_manager->getActiveReactions('\Drupal\islandora\Plugin\ContextReaction\ViewModeAlterReaction') as $reaction) {
+      // Construct the new view mode's machine name.
+      $entity_type = $entity->getEntityTypeId();
+      $mode = $reaction->execute();
+      $machine_name = "$entity_type.$mode";
 
-  foreach ($context_manager->getActiveReactions('\Drupal\islandora\Plugin\ContextReaction\ViewModeAlterReaction') as $reaction) {
-    // Construct the new view mode's machine name.
-    $entity_type = $entity->getEntityTypeId();
-    $mode = $reaction->execute();
-    $machine_name = "$entity_type.$mode";
+      // Try to load it.
+      $new_mode = $storage->load($machine_name);
 
-    // Try to load it.
-    $new_mode = $storage->load($machine_name);
-
-    // If successful, alter the view mode.
-    if ($new_mode) {
-      $view_mode = $mode;
-    }
-    else {
-      // Otherwise, leave it be, but log a message.
-      \Drupal::logger('islandora')->info("EntityViewMode $machine_name does not exist.  View mode cannot be altered.");
+      // If successful, alter the view mode.
+      if ($new_mode) {
+        $view_mode = $mode;
+      }
+      else {
+        // Otherwise, leave it be, but log a message.
+        \Drupal::logger('islandora')
+          ->info("EntityViewMode $machine_name does not exist.  View mode cannot be altered.");
+      }
     }
   }
 }

--- a/islandora.module
+++ b/islandora.module
@@ -258,10 +258,7 @@ function islandora_entity_view_mode_alter(&$view_mode, EntityInterface $entity) 
   $storage = \Drupal::service('entity_type.manager')->getStorage('entity_view_mode');
   $context_manager = \Drupal::service('context.manager');
   $current_entity = \Drupal::routeMatch()->getParameter('node');
-  $current_id = NULL;
-  if ($current_entity instanceof \Drupal\node\NodeInterface) {
-    $current_id = $current_entity->id();
-  }
+  $current_id = ($current_entity instanceof NodeInterface) ? $current_entity->id() : NULL;
   if (isset($current_id) && $current_id == $entity->id()) {
     foreach ($context_manager->getActiveReactions('\Drupal\islandora\Plugin\ContextReaction\ViewModeAlterReaction') as $reaction) {
       // Construct the new view mode's machine name.


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/969

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

Limits changing the view mode to the current node only

# What's new?
A in-depth description of the changes made by this PR. Technical details and
 possible side effects.

* Changes x feature to such that y
* Added x
* Removed y
* Does this change require documentation to be updated? 
* Does this change add any new dependencies? 
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? 
* Could this change impact execution of existing code?

# How should this be tested?

To test this create a collection and tag it with openseadragon.  Add some image objects to this collection and note that when viewing the collection object you will see the child objects rendered with the open seadragon mode.  Then apply the changes in this commit and note that the child objects now render with the teaser view mode.

You may have to clear the drupal cache to see the changes.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-CLAW/committers
