### PR TITLE
Make derivative Drupal media type configurable

### DIFF
--- a/modules/islandora_image/src/Plugin/Action/GenerateImageDerivative.php
+++ b/modules/islandora_image/src/Plugin/Action/GenerateImageDerivative.php
@@ -23,6 +23,7 @@ class GenerateImageDerivative extends AbstractGenerateDerivative {
     $config = parent::defaultConfiguration();
     $config['mimetype'] = 'image/jpeg';
     $config['path'] = '[date:custom:Y]-[date:custom:m]/[node:nid].jpg';
+    $config['destination_media_type'] = 'image';
     return $config;
   }
 

--- a/modules/islandora_video/src/Plugin/Action/GenerateVideoDerivative.php
+++ b/modules/islandora_video/src/Plugin/Action/GenerateVideoDerivative.php
@@ -24,6 +24,7 @@ class GenerateVideoDerivative extends AbstractGenerateDerivative {
     $config['path'] = '[date:custom:Y]-[date:custom:m]/[node:nid].mp4';
     $config['mimetype'] = 'video/mp4';
     $config['queue'] = 'islandora-connector-homarus';
+    $config['destination_media_type'] = 'video';
     return $config;
   }
 

--- a/src/Plugin/Action/AbstractGenerateDerivative.php
+++ b/src/Plugin/Action/AbstractGenerateDerivative.php
@@ -187,6 +187,7 @@ class AbstractGenerateDerivative extends EmitEvent {
     unset($data['derivative_term_uri']);
     unset($data['path']);
     unset($data['scheme']);
+    unset($data['destination_media_type']);
 
     return $data;
   }

--- a/src/Plugin/Action/AbstractGenerateDerivative.php
+++ b/src/Plugin/Action/AbstractGenerateDerivative.php
@@ -309,12 +309,26 @@ class AbstractGenerateDerivative extends EmitEvent {
     $this->configuration['destination_media_type'] = $form_state->getValue('destination_media_type');
   }
 
+  /**
+   * Find a media_type by id and return it or nothing.
+   *
+   * @param string $entity_id
+   *   The media type.
+   *
+   * @return EntityInterface|string
+   *   Return the loaded entity or nothing.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   *   Thrown by getStorage() if the entity type doesn't exist.
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   *   Thrown by getStorage() if the storage handler couldn't be loaded.
+   */
   protected function getEntityById($entity_id) {
     $entity_ids = $this->entityTypeManager->getStorage('media_type')
       ->getQuery()->condition('id', $entity_id)->execute();
 
     $id = reset($entity_ids);
-    if ($id !== false) {
+    if ($id !== FALSE) {
       return $this->entityTypeManager->getStorage('media_type')->load($id);
     }
     return '';

--- a/src/Plugin/Action/AbstractGenerateDerivative.php
+++ b/src/Plugin/Action/AbstractGenerateDerivative.php
@@ -315,7 +315,7 @@ class AbstractGenerateDerivative extends EmitEvent {
    * @param string $entity_id
    *   The media type.
    *
-   * @return EntityInterface|string
+   * @return \Drupal\Core\Entity\EntityInterface|string
    *   Return the loaded entity or nothing.
    *
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException

--- a/src/Plugin/Action/AbstractGenerateDerivative.php
+++ b/src/Plugin/Action/AbstractGenerateDerivative.php
@@ -126,6 +126,7 @@ class AbstractGenerateDerivative extends EmitEvent {
       'derivative_term_uri' => '',
       'mimetype' => '',
       'args' => '',
+      'destination_media_type' => '',
       'scheme' => file_default_scheme(),
       'path' => '[date:custom:Y]-[date:custom:m]/[node:nid].bin',
     ];
@@ -165,7 +166,7 @@ class AbstractGenerateDerivative extends EmitEvent {
 
     $route_params = [
       'node' => $entity->id(),
-      'media_type' => $source_media->bundle(),
+      'media_type' => $this->configuration['destination_media_type'],
       'taxonomy_term' => $derivative_term->id(),
     ];
     $data['destination_uri'] = Url::fromRoute('islandora.media_source_put_to_node', $route_params)
@@ -215,6 +216,14 @@ class AbstractGenerateDerivative extends EmitEvent {
       '#default_value' => $this->utils->getTermForUri($this->configuration['derivative_term_uri']),
       '#required' => TRUE,
       '#description' => t('Term indicating the derivative media'),
+    ];
+    $form['destination_media_type'] = [
+      '#type' => 'entity_autocomplete',
+      '#target_type' => 'media_type',
+      '#title' => t('Derivative media type'),
+      '#default_value' => $this->getEntityById($this->configuration['destination_media_type']),
+      '#required' => TRUE,
+      '#description' => t('The Drupal media type to create with this derivative, can be different than the source'),
     ];
     $form['mimetype'] = [
       '#type' => 'textfield',
@@ -296,6 +305,18 @@ class AbstractGenerateDerivative extends EmitEvent {
     $this->configuration['args'] = $form_state->getValue('args');
     $this->configuration['scheme'] = $form_state->getValue('scheme');
     $this->configuration['path'] = trim($form_state->getValue('path'), '\\/');
+    $this->configuration['destination_media_type'] = $form_state->getValue('destination_media_type');
+  }
+
+  protected function getEntityById($entity_id) {
+    $entity_ids = $this->entityTypeManager->getStorage('media_type')
+      ->getQuery()->condition('id', $entity_id)->execute();
+
+    $id = reset($entity_ids);
+    if ($id !== false) {
+      return $this->entityTypeManager->getStorage('media_type')->load($id);
+    }
+    return '';
   }
 
 }

--- a/tests/src/Functional/FormDisplayAlterReactionTest.php
+++ b/tests/src/Functional/FormDisplayAlterReactionTest.php
@@ -40,7 +40,7 @@ class FormDisplayAlterReactionTest extends IslandoraFunctionalTestBase {
     $url = $this->getUrl();
 
     // Visit the edit url and make sure we're on the default form display
-    // (e.g. there's an autocomplete for the member of field);
+    // (e.g. there's an autocomplete for the member of field).
     $this->drupalGet($url . "/edit");
     $this->assertSession()->pageTextContains("Member Of");
 
@@ -62,4 +62,3 @@ class FormDisplayAlterReactionTest extends IslandoraFunctionalTestBase {
   }
 
 }
-


### PR DESCRIPTION
Resolves: https://github.com/Islandora-CLAW/CLAW/issues/986

# What does this Pull Request do?

To allow for Image and Video events to share code we (I) tried to use the source media's bundle. But this causes problems when your source media is one type but the derivative should be another.

This PR adds a configuration option (Derivative media type) to the Action to set the destination media type which is used in the file_upload_uri when putting a new File into Drupal.

# What's new?

* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?

Before the PR, adding a Tiff as a File and you would end up with no derivatives and a lot of errors in the log.

After you should get your correct derivatives back in Drupal.

# Interested parties
@Islandora-CLAW/committers 
