### PR TITLE
Allow JSON-LD @Type to be configurable based on a specified Content Entity field

### DIFF
--- a/src/Plugin/Condition/EntityBundle.php
+++ b/src/Plugin/Condition/EntityBundle.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Drupal\islandora\Plugin\Condition;
+
+use Drupal\Core\Condition\ConditionPluginBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Provides a 'Entity Bundle' condition.
+ *
+ * @Condition(
+ *   id = "entity_bundle",
+ *   label = @Translation("Entity Bundle"),
+ *   context = {
+ *     "node" = @ContextDefinition("entity:node", label = @Translation("Node")),
+ *     "taxonomy_term" = @ContextDefinition("entity:taxonomy_term", label = @Translation("Term"))
+ *   }
+ * )
+ */
+class EntityBundle extends ConditionPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $options = [];
+    foreach (['node', 'taxonomy_term'] as $content_entity) {
+      $bundles = \Drupal::service('entity_type.bundle.info')->getBundleInfo($content_entity);
+      foreach ($bundles as $bundle => $bundle_properties) {
+        $options[$bundle] = $this->t('@bundle (@type)', [
+          '@bundle' => $bundle_properties['label'],
+          '@type' => $content_entity,
+        ]);
+      }
+    }
+
+    $form['bundles'] = [
+      '#title' => $this->t('Bundles'),
+      '#type' => 'checkboxes',
+      '#options' => $options,
+      '#default_value' => $this->configuration['bundles'],
+    ];
+
+    return parent::buildConfigurationForm($form, $form_state);;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    $this->configuration['bundles'] = array_filter($form_state->getValue('bundles'));
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function evaluate() {
+    foreach (\Drupal::routeMatch()->getParameters()->keys() as $type) {
+      if ($this->getContext($type)->hasContextValue()) {
+        $entity = $this->getContextValue($type);
+        if (!empty($this->configuration['bundles'][$entity->bundle()])) {
+          return !$this->isNegated();
+        }
+      }
+    }
+    return $this->isNegated();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function summary() {
+    if (empty($this->configuration['bundles'])) {
+      return $this->t('No bundles are selected.');
+    }
+
+    return $this->t(
+      'Entity bundle in the list: @bundles',
+      [
+        '@bundles' => implode(', ', $this->configuration['field']),
+      ]
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return array_merge(
+      ['bundles' => []],
+      parent::defaultConfiguration()
+    );
+  }
+
+}

--- a/src/Plugin/ContextReaction/JsonldTypeAlterReaction.php
+++ b/src/Plugin/ContextReaction/JsonldTypeAlterReaction.php
@@ -1,0 +1,82 @@
+<?php
+
+
+namespace Drupal\islandora\Plugin\ContextReaction;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\islandora\ContextReaction\NormalizerAlterReaction;
+use Drupal\islandora\MediaSource\MediaSourceService;
+use Drupal\jsonld\Normalizer\NormalizerBase;
+use Drupal\media\MediaInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Alter JSON-LD Type context reaction.
+ *
+ * @ContextReaction(
+ *   id = "alter_jsonld_type",
+ *   label = @Translation("Alter JSON-LD Type")
+ * )
+ */
+class JsonldTypeAlterReaction extends NormalizerAlterReaction {
+  /**
+   * {@inheritdoc}
+   */
+  public function summary() {
+    return $this->t('Alter JSON-LD Type context reaction.');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute(EntityInterface $entity = NULL, array &$normalized = NULL, array $context = NULL) {
+    $config = $this->getConfiguration();
+    // if ((in_array($config['source_field'], array_keys($entity->getFields()))) &&
+    if (($entity->hasField($config['source_field'])) &&
+        ( !empty($entity->get($config['source_field'])->getValue() ))) {
+      if (isset($normalized['@graph']) && is_array($normalized['@graph'])) {
+        foreach ($normalized['@graph'] as &$graph) {
+          foreach($entity->get($config['source_field'])->getValue() as $type){
+            $graph['@type'][] =  NormalizerBase::escapePrefix($type['value'], $context['namespaces']);
+          }
+          \Drupal::logger('islandora')->notice(print_r($graph['@type'],TRUE));
+        }
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $options = [];
+    $fieldsArray = \Drupal::service('entity_field.manager')->getFieldMap();
+    foreach ($fieldsArray as $entity_type => $entity_fields) {
+      foreach ($entity_fields as $field => $field_properties) {
+        $options[$field] = $this->t('@field (@bundles)', [
+          '@field' => $field,
+          '@bundles' => implode(', ', array_keys($field_properties['bundles'])),
+        ]);
+      }
+    }
+
+    $config = $this->getConfiguration();
+    $form['source_field'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Source Field'),
+      '#options' => $options,
+      '#description' => $this->t("A DESCRIPTION!"),
+      '#default_value' => isset($config['source_field']) ? $config['source_field'] : '',
+    ];
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    $this->setConfiguration(['source_field' => $form_state->getValue('source_field')]);
+  }
+}

--- a/src/Plugin/ContextReaction/JsonldTypeAlterReaction.php
+++ b/src/Plugin/ContextReaction/JsonldTypeAlterReaction.php
@@ -1,16 +1,11 @@
 <?php
 
-
 namespace Drupal\islandora\Plugin\ContextReaction;
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\islandora\ContextReaction\NormalizerAlterReaction;
-use Drupal\islandora\MediaSource\MediaSourceService;
 use Drupal\jsonld\Normalizer\NormalizerBase;
-use Drupal\media\MediaInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Alter JSON-LD Type context reaction.
@@ -21,6 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * )
  */
 class JsonldTypeAlterReaction extends NormalizerAlterReaction {
+
   /**
    * {@inheritdoc}
    */
@@ -33,15 +29,13 @@ class JsonldTypeAlterReaction extends NormalizerAlterReaction {
    */
   public function execute(EntityInterface $entity = NULL, array &$normalized = NULL, array $context = NULL) {
     $config = $this->getConfiguration();
-    // if ((in_array($config['source_field'], array_keys($entity->getFields()))) &&
     if (($entity->hasField($config['source_field'])) &&
-        ( !empty($entity->get($config['source_field'])->getValue() ))) {
+        (!empty($entity->get($config['source_field'])->getValue()))) {
       if (isset($normalized['@graph']) && is_array($normalized['@graph'])) {
         foreach ($normalized['@graph'] as &$graph) {
-          foreach($entity->get($config['source_field'])->getValue() as $type){
-            $graph['@type'][] =  NormalizerBase::escapePrefix($type['value'], $context['namespaces']);
+          foreach ($entity->get($config['source_field'])->getValue() as $type) {
+            $graph['@type'][] = NormalizerBase::escapePrefix($type['value'], $context['namespaces']);
           }
-          \Drupal::logger('islandora')->notice(print_r($graph['@type'],TRUE));
         }
       }
     }
@@ -79,4 +73,5 @@ class JsonldTypeAlterReaction extends NormalizerAlterReaction {
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
     $this->setConfiguration(['source_field' => $form_state->getValue('source_field')]);
   }
+
 }

--- a/src/Plugin/ContextReaction/JsonldTypeAlterReaction.php
+++ b/src/Plugin/ContextReaction/JsonldTypeAlterReaction.php
@@ -61,7 +61,7 @@ class JsonldTypeAlterReaction extends NormalizerAlterReaction {
       '#type' => 'select',
       '#title' => $this->t('Source Field'),
       '#options' => $options,
-      '#description' => $this->t("A DESCRIPTION!"),
+      '#description' => $this->t("Select the field containing the type predicates."),
       '#default_value' => isset($config['source_field']) ? $config['source_field'] : '',
     ];
     return $form;

--- a/src/Plugin/ContextReaction/JsonldTypeAlterReaction.php
+++ b/src/Plugin/ContextReaction/JsonldTypeAlterReaction.php
@@ -29,12 +29,27 @@ class JsonldTypeAlterReaction extends NormalizerAlterReaction {
    */
   public function execute(EntityInterface $entity = NULL, array &$normalized = NULL, array $context = NULL) {
     $config = $this->getConfiguration();
+    // Use a pre-configured field as the source of the additional @type.
     if (($entity->hasField($config['source_field'])) &&
         (!empty($entity->get($config['source_field'])->getValue()))) {
       if (isset($normalized['@graph']) && is_array($normalized['@graph'])) {
         foreach ($normalized['@graph'] as &$graph) {
           foreach ($entity->get($config['source_field'])->getValue() as $type) {
-            $graph['@type'][] = NormalizerBase::escapePrefix($type['value'], $context['namespaces']);
+            // If the configured field is using an entity reference,
+            // we will see if it uses the core config's field_external_uri.
+            if (array_key_exists('target_id', $type)) {
+              $target_type = $entity->get($config['source_field'])->getFieldDefinition()->getSetting('target_type');
+              $referenced_entity = \Drupal::entityTypeManager()->getStorage($target_type)->load($type['target_id']);
+              if ($referenced_entity->hasField('field_external_uri') &&
+                  !empty($referenced_entity->get('field_external_uri')->getValue())) {
+                foreach ($referenced_entity->get('field_external_uri')->getValue() as $value) {
+                  $graph['@type'][] = $value['uri'];
+                }
+              }
+            }
+            else {
+              $graph['@type'][] = NormalizerBase::escapePrefix($type['value'], $context['namespaces']);
+            }
           }
         }
       }


### PR DESCRIPTION
**GitHub Issue**: [Issue 889](https://github.com/Islandora-CLAW/CLAW/issues/889)

# What does this Pull Request do?

Adds a new Condition Plugin allowing users to specify which bundles apply. Adds a new Reaction Plugin to alter the JSON-LD's `@type` attribute based on the predicate values in the configured field.

# What's new?

* Added
    - EntityBundle Condition Plugin
    - JsonldTypeAlterReaction Reaction Plugin
* Does this change require documentation to be updated? maybe?
* Does this change add any new dependencies? no.
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? Only if you want it.
* Could this change impact execution of existing code? no.

# How should this be tested?

- Apply this PR to the islandora module.
- Clear cache (otherwise the new condition and reaction plugins won't show up in your lists later)
- Either:
    - Create a field on a content type or taxonomy where a user can enter or select a type predicate,
    - OR Checkout the [controlled_access_terms issue-889 branch](https://github.com/Islandora-CLAW/controlled_access_terms/tree/issue-889) and feature import the changes. (Creates a `field_type` field for Corporate Bodies with some default schema predicates.)
- Create a new Context using, at least, the JsonldTypeAlterReaction with the new field you created. If you are using the setup provided by controlled_access_terms issue-889, then you can import the config below:
```
uuid: c23f9c1c-1dbb-4958-a2e8-639fc4c291a6
langcode: en
status: true
dependencies:
  module:
    - islandora
name: alter_json_ld_type
label: 'Alter JSON-LD Type'
group: Islandora
description: 'Adds additional @type to JSON-LD based on configured field'
requireAllConditions: false
disabled: false
conditions:
  entity_bundle:
    id: entity_bundle
    bundles:
      corporate_body: corporate_body
    negate: 0
    uuid: ddb49e9e-0d59-4490-93bb-22a2ceaa6c1d
    context_mapping:
      node: '@node.node_route_context:node'
      taxonomy_term: '@islandora.taxonomy_term_route_context_provider:taxonomy_term'
reactions:
  alter_jsonld_type:
    id: alter_jsonld_type
    source_field: field_type
    saved: false
weight: 0
```
- Create a new node/taxonomy_term that uses the configured field.
- Viewing the node/taxonomy_term's JSON-LD will show the additional types.
- Searching for it in Blazegraph or Fedora will also display the additional types.

# Interested parties
@Islandora-CLAW/committers (esp @dannylamb and @patdunlavey)
