### PR TITLE
Add userid option to migrate:import

### DIFF
--- a/drush.services.yml
+++ b/drush.services.yml
@@ -1,0 +1,5 @@
+services:
+  islandora.commands:
+    class: \Drupal\islandora\Commands\IslandoraCommands
+    tags:
+      - { name: drush.command }

--- a/src/Commands/IslandoraCommands.php
+++ b/src/Commands/IslandoraCommands.php
@@ -4,80 +4,79 @@ namespace Drupal\islandora\Commands;
 
 use Consolidation\AnnotatedCommand\CommandData;
 use Drupal\Core\Session\UserSession;
-use Drupal\Core\Session\AccountSwitcherInterface;
-use Drupal\migrate_tools\Commands\MigrateToolsCommands;
 use Drupal\user\Entity\User;
 use Drush\Commands\DrushCommands;
 
 /**
- * Adds a userid option to migrate:import
+ * Adds a userid option to migrate:import.
  *
  * ... because the --user option was removed from drush 9.
  */
 class IslandoraCommands extends DrushCommands {
 
   /**
-  * @hook option migrate:import
-  * @option userid User ID to run the migration.
-  */
-  public function optionsetImportUser($options = ['userid' => self::REQ])
-  {
+   * Add the userid option.
+   *
+   * @hook option migrate:import
+   * @option userid User ID to run the migration.
+   */
+  public function optionsetImportUser($options = ['userid' => self::REQ]) {
   }
 
   /**
+   * Validate the provided userid.
+   *
    * @hook validate migrate:import
    */
-  public function validateUser(CommandData $commandData)
-  {
+  public function validateUser(CommandData $commandData) {
     $userid = $commandData->input()->getOption('userid');
-    if($userid)
-    {
-      $account = \Drupal\user\Entity\User::load($userid);
+    if ($userid) {
+      $account = User::load($userid);
       if (!$account) {
-          throw new \Exception("User ID does not match an existing user.");
+        throw new \Exception("User ID does not match an existing user.");
       }
     }
   }
 
   /**
-  * @hook pre-command migrate:import
-  */
-  public function preImport(CommandData $commandData)
-  {
-    //
+   * Switch the active user account to perform the import.
+   *
+   * @hook pre-command migrate:import
+   */
+  public function preImport(CommandData $commandData) {
     $userid = $commandData->input()->getOption('userid');
-    if ($userid)
-    {
-      $account = \Drupal\user\Entity\User::load($userid);
+    if ($userid) {
+      $account = User::load($userid);
       $accountSwitcher = \Drupal::service('account_switcher');
       $userSession = new UserSession([
-                                      'uid' => $account->id(),
-                                      'name'=>$account->getUsername(),
-                                      'roles'=>$account->getRoles()
-                                    ]);
+        'uid'   => $account->id(),
+        'name'  => $account->getUsername(),
+        'roles' => $account->getRoles(),
+      ]);
       $accountSwitcher->switchTo($userSession);
       $this->logger()->notice(
           dt(
               'Now acting as user ID @id',
-              ['@id'=>\Drupal::currentUser()->id()]
+              ['@id' => \Drupal::currentUser()->id()]
             )
       );
     }
   }
 
   /**
+   * Switch the user back once the migration is complete.
+   *
    * @hook post-command migrate:import
    */
-  public function postImport($result, CommandData $commandData)
-  {
-    if ($commandData->input()->getOption('userid'))
-    {
+  public function postImport($result, CommandData $commandData) {
+    if ($commandData->input()->getOption('userid')) {
       $accountSwitcher = \Drupal::service('account_switcher');
       $this->logger()->notice(dt(
                                   'Switching back from user @uid.',
-                                  ['@uid'=>\Drupal::currentUser()->id()]
+                                  ['@uid' => \Drupal::currentUser()->id()]
                                 ));
       $accountSwitcher->switchBack();
     }
   }
+
 }

--- a/src/Commands/IslandoraCommands.php
+++ b/src/Commands/IslandoraCommands.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Drupal\islandora\Commands;
+
+use Consolidation\AnnotatedCommand\CommandData;
+use Drupal\Core\Session\UserSession;
+use Drupal\Core\Session\AccountSwitcherInterface;
+use Drupal\migrate_tools\Commands\MigrateToolsCommands;
+use Drupal\user\Entity\User;
+use Drush\Commands\DrushCommands;
+
+/**
+ * Adds a userid option to migrate:import
+ *
+ * ... because the --user option was removed from drush 9.
+ */
+class IslandoraCommands extends DrushCommands {
+
+  /**
+  * @hook option migrate:import
+  * @option userid User ID to run the migration.
+  */
+  public function optionsetImportUser($options = ['userid' => self::REQ])
+  {
+  }
+
+  /**
+   * @hook validate migrate:import
+   */
+  public function validateUser(CommandData $commandData)
+  {
+    $userid = $commandData->input()->getOption('userid');
+    if($userid)
+    {
+      $account = \Drupal\user\Entity\User::load($userid);
+      if (!$account) {
+          throw new \Exception("User ID does not match an existing user.");
+      }
+    }
+  }
+
+  /**
+  * @hook pre-command migrate:import
+  */
+  public function preImport(CommandData $commandData)
+  {
+    //
+    $userid = $commandData->input()->getOption('userid');
+    if ($userid)
+    {
+      $account = \Drupal\user\Entity\User::load($userid);
+      $accountSwitcher = \Drupal::service('account_switcher');
+      $userSession = new UserSession([
+                                      'uid' => $account->id(),
+                                      'name'=>$account->getUsername(),
+                                      'roles'=>$account->getRoles()
+                                    ]);
+      $accountSwitcher->switchTo($userSession);
+      $this->logger()->notice(
+          dt(
+              'Now acting as user ID @id',
+              ['@id'=>\Drupal::currentUser()->id()]
+            )
+      );
+    }
+  }
+
+  /**
+   * @hook post-command migrate:import
+   */
+  public function postImport($result, CommandData $commandData)
+  {
+    if ($commandData->input()->getOption('userid'))
+    {
+      $accountSwitcher = \Drupal::service('account_switcher');
+      $this->logger()->notice(dt(
+                                  'Switching back from user @uid.',
+                                  ['@uid'=>\Drupal::currentUser()->id()]
+                                ));
+      $accountSwitcher->switchBack();
+    }
+  }
+}


### PR DESCRIPTION
**GitHub Issue**: ([Issue 988](https://github.com/Islandora-CLAW/CLAW/issues/988))

# What does this Pull Request do?

Adds a userid option to Drush migrate:import command that uses the Drupal Account Switch to perform the migration as the specified user.

# What's new?

* Changes Drush migrate:import feature to such that is has a userid option
* Does this change require documentation to be updated? Probably.
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? No, but it helps get us ready for Fedora 5.
* Could this change impact execution of existing code? No.

# How should this be tested?

Currently, performing a migration using Drush migrate will technically work, but all the derivative creations will fail. 

So:
1. roll back the migration `drush -l http://localhost:8000 mr --all`.
2. Apply the PR
3. run the migration e.g. `drush -l http://localhost:8000 mim --userid=1 --all` and this time your derivatives should generate successfully for added items.

# Interested parties
@Islandora-CLAW/committers, esp @whikloj and @dannylamb
