### PR TITLE
Work on https://github.com/Islandora-CLAW/CLAW/issues/1014.

### DIFF
--- a/src/Plugin/Action/EmitFileEvent.php
+++ b/src/Plugin/Action/EmitFileEvent.php
@@ -104,7 +104,8 @@ class EmitFileEvent extends EmitEvent {
 
     $data = parent::generateData($entity);
     if (isset($flysystem_config[$scheme]) && $flysystem_config[$scheme]['driver'] == 'fedora') {
-      // $uri for files may contain 'fedora:///' so we need to replace the three / with two.
+      // $uri for files may contain 'fedora:///' so we need to replace
+      // the three / with two.
       if (strpos($uri, 'fedora:///') !== FALSE) {
         $uri = str_replace('fedora:///', 'fedora://', $uri);
       }

--- a/src/Plugin/Action/EmitFileEvent.php
+++ b/src/Plugin/Action/EmitFileEvent.php
@@ -104,10 +104,10 @@ class EmitFileEvent extends EmitEvent {
 
     $data = parent::generateData($entity);
     if (isset($flysystem_config[$scheme]) && $flysystem_config[$scheme]['driver'] == 'fedora') {
-      // $uri for files may contain 'fedora:///' so we need to replace
+      // Fdora $uri for files may contain ':///' so we need to replace
       // the three / with two.
-      if (strpos($uri, 'fedora:///') !== FALSE) {
-        $uri = str_replace('fedora:///', 'fedora://', $uri);
+      if (strpos($uri, $scheme . ':///') !== FALSE) {
+        $uri = str_replace($scheme . ':///', $scheme . '://', $uri);
       }
       $data['fedora_uri'] = str_replace("$scheme://", $flysystem_config[$scheme]['config']['root'], $uri);
     }

--- a/src/Plugin/Action/EmitFileEvent.php
+++ b/src/Plugin/Action/EmitFileEvent.php
@@ -104,6 +104,10 @@ class EmitFileEvent extends EmitEvent {
 
     $data = parent::generateData($entity);
     if (isset($flysystem_config[$scheme]) && $flysystem_config[$scheme]['driver'] == 'fedora') {
+      // $uri for files may contain 'fedora:///' so we need to replace the three / with two.
+      if (strpos($uri, 'fedora:///') !== FALSE) {
+        $uri = str_replace('fedora:///', 'fedora://', $uri);
+      }
       $data['fedora_uri'] = str_replace("$scheme://", $flysystem_config[$scheme]['config']['root'], $uri);
     }
     return $data;


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1014

# What does this Pull Request do?

Fixes URIs persisted to Gemini like `http://localhost:8080/fcrepo/rest//islandora_2_MODS.xml` so that they don't contain double forward slashes (`//`).

# What's new?

Within the `src/Plugin/Action/EmitFileEvent.php` class, checks to see if the incoming URI for the file contains a redundant `/`, and if so, removes it.

# How should this be tested?

Since this error manifested itself in a migration from a 7.x instance, you will need one of those to test this fix. 

1. Install the Migrate 7.x CLAW module (in /var/www/html/drupal, run `composer require islandora/migrate_7x_claw`)
1. Configure your migration as described in https://github.com/Islandora-Devops/migrate_7x_claw.
1. Enable the migration modules by running `drush en islandora_migrate_7x_claw_feature`.
1. Migrate some objects from an Islandora 7.x instance.
1. Fire up the MySQL client on the CLAW  VM and in the gemini database, issue the query `select * from Gemini\G`. You should see values in the `fedora_uri` fields that contain double forward slashes (`//`), e.g. `http://localhost:8080/fcrepo/rest//islandora_2_MODS.xml`.
1. Roll back your migration by running `drush -y migrate:rollback --group islandora_7x`.
1. Within /var/www/html/drupal/web/modules/contrib/islandora, run `sudo git reset --hard` to reset permissions on files changed by Ansible (?).
1. Check out the `mjordan:issue-1014` branch.
1. Rerun your migration by running `drush -y mim --userid=1 --group islandora_7x`.
1. Check your gemini database again. No `fedora_uri` values should contain double slashes (`//`), and all URIs should look otherwise correct.

# Interested parties
@dannylamb, other @Islandora-CLAW/committers
