### PR TITLE
Make JWT Expiry configurable - Issue 1030

### DIFF
--- a/src/EventSubscriber/JwtEventSubscriber.php
+++ b/src/EventSubscriber/JwtEventSubscriber.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\islandora\EventSubscriber;
 
+use Drupal\islandora\Form\IslandoraSettingsForm;
 use Drupal\jwt\Authentication\Event\JwtAuthValidateEvent;
 use Drupal\jwt\Authentication\Event\JwtAuthValidEvent;
 use Drupal\jwt\Authentication\Event\JwtAuthGenerateEvent;
@@ -88,7 +89,10 @@ class JwtEventSubscriber implements EventSubscriberInterface {
 
     // Standard claims, validated at JWT validation time.
     $event->addClaim('iat', time());
-    $event->addClaim('exp', strtotime('+2 hour'));
+    $expiry_setting = \Drupal::config(IslandoraSettingsForm::CONFIG_NAME)
+      ->get(IslandoraSettingsForm::JWT_EXPIRY);
+    $expiry = $expiry_setting ? $expiry_setting : '+2 hour';
+    $event->addClaim('exp', strtotime($expiry));
     $event->addClaim('webid', $this->currentUser->id());
     $event->addClaim('iss', $base_secure_url);
 

--- a/src/Form/IslandoraSettingsForm.php
+++ b/src/Form/IslandoraSettingsForm.php
@@ -15,6 +15,7 @@ class IslandoraSettingsForm extends ConfigFormBase {
 
   const CONFIG_NAME = 'islandora.settings';
   const BROKER_URL = 'broker_url';
+  const JWT_EXPIRY = 'jwt_expiry';
 
   /**
    * {@inheritdoc}
@@ -42,6 +43,12 @@ class IslandoraSettingsForm extends ConfigFormBase {
       '#type' => 'textfield',
       '#title' => $this->t('Broker URL'),
       '#default_value' => $config->get(self::BROKER_URL) ? $config->get(self::BROKER_URL) : 'tcp://localhost:61613',
+    ];
+
+    $form[self::JWT_EXPIRY] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('JWT Expiry'),
+      '#default_value' => $config->get(self::JWT_EXPIRY) ? $config->get(self::JWT_EXPIRY) : '+2 hour',
     ];
 
     return parent::buildForm($form, $form_state);
@@ -74,6 +81,18 @@ class IslandoraSettingsForm extends ConfigFormBase {
         )
       );
     }
+
+    // Validate jwt expiry as a valid time string.
+    $expiry = $form_state->getValue(self::JWT_EXPIRY);
+    if (strtotime($expiry) === false) {
+      $form_state->setErrorByName(
+        self::JWT_EXPIRY,
+        $this->t(
+          '"@exipry" is not a valid time or interval expression.',
+          ['@expiry' => $expiry]
+        )
+      );
+    }
   }
 
   /**
@@ -84,6 +103,7 @@ class IslandoraSettingsForm extends ConfigFormBase {
 
     $config
       ->set(self::BROKER_URL, $form_state->getValue(self::BROKER_URL))
+      ->set(self::JWT_EXPIRY, $form_state->getValue(self::JWT_EXPIRY))
       ->save();
 
     parent::submitForm($form, $form_state);

--- a/src/Form/IslandoraSettingsForm.php
+++ b/src/Form/IslandoraSettingsForm.php
@@ -84,7 +84,7 @@ class IslandoraSettingsForm extends ConfigFormBase {
 
     // Validate jwt expiry as a valid time string.
     $expiry = $form_state->getValue(self::JWT_EXPIRY);
-    if (strtotime($expiry) === false) {
+    if (strtotime($expiry) === FALSE) {
       $form_state->setErrorByName(
         self::JWT_EXPIRY,
         $this->t(


### PR DESCRIPTION
**GitHub Issue**: /Islandora-CLAW/CLAW/issues/1030

See also the IRC conversations linked from the issue.

# What does this Pull Request do?

This PR amends the Islandora core setting form to include the option of setting a JWT expiration time (default is currently hard-coded as '+2 hour') and updates the JwtEventSubscription to use the setting (if available, the default '+2 hour' if not).

# What's new?

* Changes JwtEventSubscriber feature to such that the expiration is pulled from configuration.
* Added JWT Setting to Islandora core settings form.

# How should this be tested?

- Add the debug setting to Chullo FedoraApi class. Add `$options['debug'] = TRUE;` [about here](https://github.com/Islandora-CLAW/chullo/blob/master/src/FedoraApi.php#L76).
- Start a migration of any sort that pushes to Fedora (you can limit it to just one item for debugging purposes).
- You will start to see authorization tokens appear `Authorization: Bearer ...`. Decode the JWT. The [JWT homepage](https://jwt.io/) has a decoding/debugger tool that makes this easy; just copy paste in there and it will show you the decoded content. The exipry is given as an epoc int, but mouse over the value to see the human-readable form. By default it should be about two hours from when the migration was started.
- Apply the PR
- Adjust the exipry setting on the Islandora core settings form. (E.g. '+2 days'.)
- Start another migration and check the authorization JWT again. The expiry should now reflect the update expiry setting from your form.

# Interested parties
@dannylamb or any other @Islandora-CLAW/committers
