### PR TITLE
Missing a fclose :S

### DIFF
--- a/src/MediaSource/MediaSourceService.php
+++ b/src/MediaSource/MediaSourceService.php
@@ -206,6 +206,8 @@ class MediaSourceService {
 
     $content_length = stream_copy_to_stream($resource, $destination);
 
+    fclose($destination);
+
     if ($content_length === FALSE) {
       throw new HttpException(500, "Request body could not be copied to $uri");
     }


### PR DESCRIPTION
**GitHub Issue**: Part of https://github.com/Islandora-CLAW/CLAW/issues/978

# What does this Pull Request do?

Adds an `fclose` to the REST endpoint that adds Media to files via PUT.

# How should this be tested?

You should no longer hit the file descriptors wall as per https://github.com/Islandora-CLAW/CLAW/issues/978

# Interested parties
@seth-shaw-unlv 