### PR TITLE
Display Fedora URI in Drupal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "drupal/migrate_source_csv" : "^2.1",
     "drupal/token" : "^1.3",
     "drupal/flysystem" : "^1.0",
-    "islandora/chullo" : "^0.2.0"
+    "islandora/crayfish-commons": "^0.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^6",

--- a/config/schema/islandora.schema.yml
+++ b/config/schema/islandora.schema.yml
@@ -11,6 +11,9 @@ islandora.settings:
     broadcast_queue:
       type: string
       label: 'Queue that handles distributing messages amongst multiple recipients'
+    jwt_expiry:
+      type: string
+      label: 'How long JWTs should last before expiring.'
     gemini_url:
       type: uri
       label: 'Url to Gemini microservice'

--- a/config/schema/islandora.schema.yml
+++ b/config/schema/islandora.schema.yml
@@ -11,6 +11,15 @@ islandora.settings:
     broadcast_queue:
       type: string
       label: 'Queue that handles distributing messages amongst multiple recipients'
+    gemini_url:
+      type: uri
+      label: 'Url to Gemini microservice'
+    gemini_pseudo_bundles:
+      type: sequence
+      label: 'List of node, media and taxonomy terms that should include the linked Fedora URI'
+      sequence:
+        type: string
+
 
 action.configuration.emit_node_event:
   type: mapping

--- a/islandora.module
+++ b/islandora.module
@@ -353,50 +353,50 @@ function islandora_form_block_form_alter(&$form, FormStateInterface $form_state,
  * Implements hook_entity_extra_field_info().
  */
 function islandora_entity_extra_field_info() {
-    $config_factory = \Drupal::service('config.factory')->get(IslandoraSettingsForm::CONFIG_NAME);
-    $extra_field = [];
+  $config_factory = \Drupal::service('config.factory')->get(IslandoraSettingsForm::CONFIG_NAME);
+  $extra_field = [];
 
-    $pseudo_bundles = $config_factory->get(IslandoraSettingsForm::GEMINI_PSEUDO);
+  $pseudo_bundles = $config_factory->get(IslandoraSettingsForm::GEMINI_PSEUDO);
 
-    foreach ($pseudo_bundles as $key) {
-        list($bundle, $content_entity) = explode(":", $key);
-        $extra_field[$content_entity][$bundle]['display']['field_gemini_uri'] = [
-            'label' => t('Fedora URI'),
-            'description' => t('The URI to the persistent'),
-            'weight' => 100,
-            'visible' => TRUE,
-        ];
-    }
-    return $extra_field;
+  foreach ($pseudo_bundles as $key) {
+    list($bundle, $content_entity) = explode(":", $key);
+    $extra_field[$content_entity][$bundle]['display']['field_gemini_uri'] = [
+      'label' => t('Fedora URI'),
+      'description' => t('The URI to the persistent'),
+      'weight' => 100,
+      'visible' => TRUE,
+    ];
+  }
+  return $extra_field;
 }
 
 /**
  * Implements hook_entity_view().
  */
 function islandora_entity_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
-    if ($view_mode == 'full') {
-        if ($display->getComponent('field_gemini_uri')) {
-            $gemini = \Drupal::service('islandora.gemini.lookup');
-            if ($gemini instanceof GeminiLookup) {
-                $fedora_uri = $gemini->lookup($entity);
-                if (!is_null($fedora_uri)) {
-                    $build['field_gemini_uri'] = [
-                        '#type' => 'container',
-                        '#attributes' => [
-                            'id' => 'field-gemini-uri',
-                        ],
-                        'internal_label' => [
-                            '#type' => 'item',
-                            '#title' => t('Fedora URI'),
-                            'internal_uri' => [
-                                '#type' => 'link',
-                                '#title' => t($fedora_uri),
-                                '#url' => Url::fromUri($fedora_uri),
-                            ],
-                        ],
-                    ];
-                }
-            }
+  if ($view_mode == 'full') {
+    if ($display->getComponent('field_gemini_uri')) {
+      $gemini = \Drupal::service('islandora.gemini.lookup');
+      if ($gemini instanceof GeminiLookup) {
+        $fedora_uri = $gemini->lookup($entity);
+        if (!is_null($fedora_uri)) {
+          $build['field_gemini_uri'] = [
+            '#type' => 'container',
+            '#attributes' => [
+              'id' => 'field-gemini-uri',
+            ],
+            'internal_label' => [
+              '#type' => 'item',
+              '#title' => t('Fedora URI'),
+              'internal_uri' => [
+                '#type' => 'link',
+                '#title' => t("@url", ['@url' => $fedora_uri]),
+                '#url' => Url::fromUri($fedora_uri),
+              ],
+            ],
+          ];
         }
+      }
     }
+  }
 }

--- a/islandora.module
+++ b/islandora.module
@@ -14,8 +14,12 @@
  * @author Diego Pino Navarro <dpino@metro.org> https://github.com/diegopino
  */
 
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\islandora\Form\IslandoraSettingsForm;
+use Drupal\islandora\GeminiLookup;
 use Drupal\node\NodeInterface;
 use Drupal\media\MediaInterface;
 use Drupal\file\FileInterface;
@@ -343,4 +347,56 @@ function islandora_form_block_form_alter(&$form, FormStateInterface $form_state,
   unset($form['visibility']['file_uses_filesystem']);
   unset($form['visibility']['node_has_term']);
   unset($form['visibility']['media_uses_filesystem']);
+}
+
+/**
+ * Implements hook_entity_extra_field_info().
+ */
+function islandora_entity_extra_field_info() {
+    $config_factory = \Drupal::service('config.factory')->get(IslandoraSettingsForm::CONFIG_NAME);
+    $extra_field = [];
+
+    $pseudo_bundles = $config_factory->get(IslandoraSettingsForm::GEMINI_PSEUDO);
+
+    foreach ($pseudo_bundles as $key) {
+        list($bundle, $content_entity) = explode(":", $key);
+        $extra_field[$content_entity][$bundle]['display']['field_gemini_uri'] = [
+            'label' => t('Fedora URI'),
+            'description' => t('The URI to the persistent'),
+            'weight' => 100,
+            'visible' => TRUE,
+        ];
+    }
+    return $extra_field;
+}
+
+/**
+ * Implements hook_entity_view().
+ */
+function islandora_entity_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
+    if ($view_mode == 'full') {
+        if ($display->getComponent('field_gemini_uri')) {
+            $gemini = \Drupal::service('islandora.gemini.lookup');
+            if ($gemini instanceof GeminiLookup) {
+                $fedora_uri = $gemini->lookup($entity);
+                if (!is_null($fedora_uri)) {
+                    $build['field_gemini_uri'] = [
+                        '#type' => 'container',
+                        '#attributes' => [
+                            'id' => 'field-gemini-uri',
+                        ],
+                        'internal_label' => [
+                            '#type' => 'item',
+                            '#title' => t('Fedora URI'),
+                            'internal_uri' => [
+                                '#type' => 'link',
+                                '#title' => t($fedora_uri),
+                                '#url' => Url::fromUri($fedora_uri),
+                            ],
+                        ],
+                    ];
+                }
+            }
+        }
+    }
 }

--- a/islandora.module
+++ b/islandora.module
@@ -356,7 +356,7 @@ function islandora_entity_extra_field_info() {
   $config_factory = \Drupal::service('config.factory')->get(IslandoraSettingsForm::CONFIG_NAME);
   $extra_field = [];
 
-  $pseudo_bundles = $config_factory->get(IslandoraSettingsForm::GEMINI_PSEUDO);
+  $pseudo_bundles = $config_factory->get(IslandoraSettingsForm::GEMINI_PSEUDO) ? $config_factory->get(IslandoraSettingsForm::GEMINI_PSEUDO) : [];
 
   foreach ($pseudo_bundles as $key) {
     list($bundle, $content_entity) = explode(":", $key);

--- a/islandora.services.yml
+++ b/islandora.services.yml
@@ -51,3 +51,10 @@ services:
   islandora.utils:
     class: Drupal\islandora\IslandoraUtils
     arguments: ['@entity_type.manager', '@entity_field.manager', '@entity.query', '@context.manager', '@flysystem_factory']
+  islandora.gemini.client:
+    class: Islandora\Crayfish\Commons\Client\GeminiClient
+    factory: ['Drupal\islandora\GeminiClientFactory', create]
+    arguments: ['@config.factory', '@logger.channel.islandora']
+  islandora.gemini.lookup:
+    class: Drupal\islandora\GeminiLookup
+    arguments: ['@islandora.gemini.client', '@jwt.authentication.jwt', '@logger.channel.islandora']

--- a/src/Form/IslandoraSettingsForm.php
+++ b/src/Form/IslandoraSettingsForm.php
@@ -113,6 +113,7 @@ class IslandoraSettingsForm extends ConfigFormBase {
       '#type' => 'details',
       '#title' => $this->t('Bundles with Gemini URI Pseudo field'),
       '#description' => $this->t('The selected bundles can display the pseudo-field showing the Gemini linked URI. Configured in the field display.'),
+      '#open' => TRUE,
       self::GEMINI_PSEUDO => [
         '#type' => 'checkboxes',
         '#options' => $options,
@@ -162,6 +163,9 @@ class IslandoraSettingsForm extends ConfigFormBase {
       );
     }
 
+    // Needed for the elseif below
+    $pseudo_types = array_filter($form_state->getValue(self::GEMINI_PSEUDO));
+
     // Validate Gemini URL by validating the URL.
     $geminiUrlValue = trim($form_state->getValue(self::GEMINI_URL));
     if (!empty($geminiUrlValue)) {
@@ -190,6 +194,12 @@ class IslandoraSettingsForm extends ConfigFormBase {
               )
           );
       }
+    }
+    elseif (count($pseudo_types) > 0) {
+        $form_state->setErrorByName(
+            self::GEMINI_URL,
+            $this->t('Must enter Gemini URL before selecting bundles to display a pseudo field on.')
+        );
     }
 
   }

--- a/src/Form/IslandoraSettingsForm.php
+++ b/src/Form/IslandoraSettingsForm.php
@@ -163,7 +163,7 @@ class IslandoraSettingsForm extends ConfigFormBase {
       );
     }
 
-    // Needed for the elseif below
+    // Needed for the elseif below.
     $pseudo_types = array_filter($form_state->getValue(self::GEMINI_PSEUDO));
 
     // Validate Gemini URL by validating the URL.
@@ -196,10 +196,10 @@ class IslandoraSettingsForm extends ConfigFormBase {
       }
     }
     elseif (count($pseudo_types) > 0) {
-        $form_state->setErrorByName(
-            self::GEMINI_URL,
-            $this->t('Must enter Gemini URL before selecting bundles to display a pseudo field on.')
-        );
+      $form_state->setErrorByName(
+        self::GEMINI_URL,
+        $this->t('Must enter Gemini URL before selecting bundles to display a pseudo field on.')
+      );
     }
 
   }

--- a/src/Form/IslandoraSettingsForm.php
+++ b/src/Form/IslandoraSettingsForm.php
@@ -2,11 +2,8 @@
 
 namespace Drupal\islandora\Form;
 
-use Drupal\Core\Cache\Cache;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfo;
-use Drupal\Core\Entity\EntityTypeManager;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
@@ -29,6 +26,8 @@ class IslandoraSettingsForm extends ConfigFormBase {
   const GEMINI_PSEUDO = 'gemini_pseudo_bundles';
 
   /**
+   * To list the available bundle types.
+   *
    * @var \Drupal\Core\Entity\EntityTypeBundleInfo
    */
   private $entityTypeBundleInfo;
@@ -38,17 +37,19 @@ class IslandoraSettingsForm extends ConfigFormBase {
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The factory for configuration objects.
+   * @param \Drupal\Core\Entity\EntityTypeBundleInfo $entity_type_bundle_info
+   *   The EntityTypeBundleInfo service.
    */
   public function __construct(ConfigFactoryInterface $config_factory, EntityTypeBundleInfo $entity_type_bundle_info) {
-      $this->setConfigFactory($config_factory);
-      $this->entityTypeBundleInfo = $entity_type_bundle_info;
+    $this->setConfigFactory($config_factory);
+    $this->entityTypeBundleInfo = $entity_type_bundle_info;
   }
 
   /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
-      return new static(
+    return new static(
           $container->get('config.factory'),
           $container->get('entity_type.bundle.info')
       );
@@ -98,25 +99,25 @@ class IslandoraSettingsForm extends ConfigFormBase {
 
     $options = [];
     foreach (['node', 'media', 'taxonomy_term'] as $content_entity) {
-        $bundles = $this->entityTypeBundleInfo->getBundleInfo($content_entity);
-        foreach ($bundles as $bundle => $bundle_properties) {
-            $options["{$bundle}:{$content_entity}"] =
+      $bundles = $this->entityTypeBundleInfo->getBundleInfo($content_entity);
+      foreach ($bundles as $bundle => $bundle_properties) {
+        $options["{$bundle}:{$content_entity}"] =
                 $this->t('@label (@type)', [
-                    '@label' => $bundle_properties['label'],
-                    '@type' => $content_entity,
+                  '@label' => $bundle_properties['label'],
+                  '@type' => $content_entity,
                 ]);
-        }
+      }
     }
 
     $form['bundle_container'] = [
-        '#type' => 'details',
-        '#title' => $this->t('Bundles with Gemini URI Pseudo field'),
-        '#description' => $this->t('The selected bundles can display the pseudo-field showing the Gemini linked URI. Configured in the field display.'),
-        self::GEMINI_PSEUDO => [
-            '#type' => 'checkboxes',
-            '#options' => $options,
-            '#default_value' => $selected_bundles,
-        ],
+      '#type' => 'details',
+      '#title' => $this->t('Bundles with Gemini URI Pseudo field'),
+      '#description' => $this->t('The selected bundles can display the pseudo-field showing the Gemini linked URI. Configured in the field display.'),
+      self::GEMINI_PSEUDO => [
+        '#type' => 'checkboxes',
+        '#options' => $options,
+        '#default_value' => $selected_bundles,
+      ],
     ];
     return parent::buildForm($form, $form_state);
   }
@@ -161,7 +162,7 @@ class IslandoraSettingsForm extends ConfigFormBase {
       );
     }
 
-    // Validate Gemini URL by validating the URL
+    // Validate Gemini URL by validating the URL.
     $geminiUrlValue = trim($form_state->getValue(self::GEMINI_URL));
     if (!empty($geminiUrlValue)) {
       try {
@@ -169,7 +170,7 @@ class IslandoraSettingsForm extends ConfigFormBase {
         $client = GeminiClient::create($geminiUrlValue, $this->logger('islandora'));
         $client->findByUri('http://example.org');
       }
-      // Uri is invalid
+      // Uri is invalid.
       catch (\InvalidArgumentException $e) {
         $form_state->setErrorByName(
           self::GEMINI_URL,
@@ -179,9 +180,9 @@ class IslandoraSettingsForm extends ConfigFormBase {
           )
         );
       }
-      // Uri is not available
+      // Uri is not available.
       catch (ConnectException $e) {
-          $form_state->setErrorByName(
+        $form_state->setErrorByName(
               self::GEMINI_URL,
               $this->t(
                   'Cannot connect to URL @url',

--- a/src/Form/IslandoraSettingsForm.php
+++ b/src/Form/IslandoraSettingsForm.php
@@ -157,7 +157,7 @@ class IslandoraSettingsForm extends ConfigFormBase {
       $form_state->setErrorByName(
         self::JWT_EXPIRY,
         $this->t(
-          '"@exipry" is not a valid time or interval expression.',
+          '"@expiry" is not a valid time or interval expression.',
           ['@expiry' => $expiry]
         )
       );

--- a/src/Form/IslandoraSettingsForm.php
+++ b/src/Form/IslandoraSettingsForm.php
@@ -2,11 +2,20 @@
 
 namespace Drupal\islandora\Form;
 
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfo;
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use GuzzleHttp\Exception\ConnectException;
+use Islandora\Crayfish\Commons\Client\GeminiClient;
 use Stomp\Client;
 use Stomp\Exception\StompException;
 use Stomp\StatefulStomp;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Config form for Islandora settings.
@@ -16,6 +25,34 @@ class IslandoraSettingsForm extends ConfigFormBase {
   const CONFIG_NAME = 'islandora.settings';
   const BROKER_URL = 'broker_url';
   const JWT_EXPIRY = 'jwt_expiry';
+  const GEMINI_URL = 'gemini_url';
+  const GEMINI_PSEUDO = 'gemini_pseudo_bundles';
+
+  /**
+   * @var \Drupal\Core\Entity\EntityTypeBundleInfo
+   */
+  private $entityTypeBundleInfo;
+
+  /**
+   * Constructs a \Drupal\system\ConfigFormBase object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, EntityTypeBundleInfo $entity_type_bundle_info) {
+      $this->setConfigFactory($config_factory);
+      $this->entityTypeBundleInfo = $entity_type_bundle_info;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+      return new static(
+          $container->get('config.factory'),
+          $container->get('entity_type.bundle.info')
+      );
+  }
 
   /**
    * {@inheritdoc}
@@ -51,6 +88,36 @@ class IslandoraSettingsForm extends ConfigFormBase {
       '#default_value' => $config->get(self::JWT_EXPIRY) ? $config->get(self::JWT_EXPIRY) : '+2 hour',
     ];
 
+    $form[self::GEMINI_URL] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Gemini URL'),
+      '#default_value' => $config->get(self::GEMINI_URL) ? $config->get(self::GEMINI_URL) : '',
+    ];
+
+    $selected_bundles = $config->get(self::GEMINI_PSEUDO) ? $config->get(self::GEMINI_PSEUDO) : [];
+
+    $options = [];
+    foreach (['node', 'media', 'taxonomy_term'] as $content_entity) {
+        $bundles = $this->entityTypeBundleInfo->getBundleInfo($content_entity);
+        foreach ($bundles as $bundle => $bundle_properties) {
+            $options["{$bundle}:{$content_entity}"] =
+                $this->t('@label (@type)', [
+                    '@label' => $bundle_properties['label'],
+                    '@type' => $content_entity,
+                ]);
+        }
+    }
+
+    $form['bundle_container'] = [
+        '#type' => 'details',
+        '#title' => $this->t('Bundles with Gemini URI Pseudo field'),
+        '#description' => $this->t('The selected bundles can display the pseudo-field showing the Gemini linked URI. Configured in the field display.'),
+        self::GEMINI_PSEUDO => [
+            '#type' => 'checkboxes',
+            '#options' => $options,
+            '#default_value' => $selected_bundles,
+        ],
+    ];
     return parent::buildForm($form, $form_state);
   }
 
@@ -93,17 +160,52 @@ class IslandoraSettingsForm extends ConfigFormBase {
         )
       );
     }
+
+    // Validate Gemini URL by validating the URL
+    $geminiUrlValue = trim($form_state->getValue(self::GEMINI_URL));
+    if (!empty($geminiUrlValue)) {
+      try {
+        $geminiUrl = Url::fromUri($geminiUrlValue);
+        $client = GeminiClient::create($geminiUrlValue, $this->logger('islandora'));
+        $client->findByUri('http://example.org');
+      }
+      // Uri is invalid
+      catch (\InvalidArgumentException $e) {
+        $form_state->setErrorByName(
+          self::GEMINI_URL,
+          $this->t(
+            'Cannot parse URL @url',
+            ['@url' => $geminiUrlValue]
+          )
+        );
+      }
+      // Uri is not available
+      catch (ConnectException $e) {
+          $form_state->setErrorByName(
+              self::GEMINI_URL,
+              $this->t(
+                  'Cannot connect to URL @url',
+                  ['@url' => $geminiUrlValue]
+              )
+          );
+      }
+    }
+
   }
 
   /**
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    $config = \Drupal::service('config.factory')->getEditable(self::CONFIG_NAME);
+    $config = $this->configFactory->getEditable(self::CONFIG_NAME);
+
+    $pseudo_types = array_filter($form_state->getValue(self::GEMINI_PSEUDO));
 
     $config
       ->set(self::BROKER_URL, $form_state->getValue(self::BROKER_URL))
       ->set(self::JWT_EXPIRY, $form_state->getValue(self::JWT_EXPIRY))
+      ->set(self::GEMINI_URL, $form_state->getValue(self::GEMINI_URL))
+      ->set(self::GEMINI_PSEUDO, $pseudo_types)
       ->save();
 
     parent::submitForm($form, $form_state);

--- a/src/GeminiClientFactory.php
+++ b/src/GeminiClientFactory.php
@@ -15,31 +15,33 @@ use Symfony\Component\HttpKernel\Exception\PreconditionFailedHttpException;
  */
 class GeminiClientFactory {
 
-    /**
-     * Factory function.
-     *
-     * @param \Drupal\Core\Config\ConfigFactoryInterface $config
-     *   Config.
-     *
-     * @return \Islandora\Crayfish\Commons\Client\GeminiClient
-     *   Return GeminiClient
-     *
-     * @throws \Exception
-     *   If there is no URL to connect to.
-     *
-     */
-    public static function create(ConfigFactoryInterface $config, LoggerInterface $logger) {
-        // Get broker url from config.
-        $settings = $config->get(IslandoraSettingsForm::CONFIG_NAME);
-        $geminiUrl = $settings->get(IslandoraSettingsForm::GEMINI_URL);
+  /**
+   * Factory function.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config
+   *   Config.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   The logger channel.
+   *
+   * @return \Islandora\Crayfish\Commons\Client\GeminiClient
+   *   Return GeminiClient
+   *
+   * @throws \Exception
+   *   If there is no URL to connect to.
+   */
+  public static function create(ConfigFactoryInterface $config, LoggerInterface $logger) {
+    // Get broker url from config.
+    $settings = $config->get(IslandoraSettingsForm::CONFIG_NAME);
+    $geminiUrl = $settings->get(IslandoraSettingsForm::GEMINI_URL);
 
-        // Only attempt if there is one.
-        if (!empty($geminiUrl)) {
-            return GeminiClient::create($geminiUrl, $logger);
-        }
-        else {
-            $logger->notice("Attempted to create Gemini client without a Gemini URL defined.");
-            throw new PreconditionFailedHttpException("Unable to instantiate GeminiClient, missing Gemini URI in Islandora setting.");
-        }
+    // Only attempt if there is one.
+    if (!empty($geminiUrl)) {
+      return GeminiClient::create($geminiUrl, $logger);
     }
+    else {
+      $logger->notice("Attempted to create Gemini client without a Gemini URL defined.");
+      throw new PreconditionFailedHttpException("Unable to instantiate GeminiClient, missing Gemini URI in Islandora setting.");
+    }
+  }
+
 }

--- a/src/GeminiClientFactory.php
+++ b/src/GeminiClientFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Drupal\islandora;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\islandora\Form\IslandoraSettingsForm;
+use Islandora\Crayfish\Commons\Client\GeminiClient;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpKernel\Exception\PreconditionFailedHttpException;
+
+/**
+ * Creates a GeminiClient as a Drupal service.
+ *
+ * @package Drupal\islandora
+ */
+class GeminiClientFactory {
+
+    /**
+     * Factory function.
+     *
+     * @param \Drupal\Core\Config\ConfigFactoryInterface $config
+     *   Config.
+     *
+     * @return \Islandora\Crayfish\Commons\Client\GeminiClient
+     *   Return GeminiClient
+     *
+     * @throws \Exception
+     *   If there is no URL to connect to.
+     *
+     */
+    public static function create(ConfigFactoryInterface $config, LoggerInterface $logger) {
+        // Get broker url from config.
+        $settings = $config->get(IslandoraSettingsForm::CONFIG_NAME);
+        $geminiUrl = $settings->get(IslandoraSettingsForm::GEMINI_URL);
+
+        // Only attempt if there is one.
+        if (!empty($geminiUrl)) {
+            return GeminiClient::create($geminiUrl, $logger);
+        }
+        else {
+            $logger->notice("Attempted to create Gemini client without a Gemini URL defined.");
+            throw new PreconditionFailedHttpException("Unable to instantiate GeminiClient, missing Gemini URI in Islandora setting.");
+        }
+    }
+}

--- a/src/GeminiLookup.php
+++ b/src/GeminiLookup.php
@@ -1,0 +1,90 @@
+<?php
+namespace Drupal\islandora;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\jwt\Authentication\Provider\JwtAuth;
+use Islandora\Crayfish\Commons\Client\GeminiClient;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Locates the matching Fedora URI from the Gemini database for use in a
+ * pseudo field.
+ *
+ * @package Drupal\islandora
+ */
+class GeminiLookup {
+
+    /**
+     * @var \Islandora\Crayfish\Commons\Client\GeminiClient
+     */
+    private $geminiClient;
+
+    /**
+     * @var \Drupal\jwt\Authentication\Provider\JwtAuth
+     */
+    private $jwtProvider;
+
+    /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * GeminiField constructor.
+     *
+     * @param \Islandora\Crayfish\Commons\Client\GeminiClient $client
+     *   The Gemini client
+     * @param \Psr\Log\LoggerInterface
+     *   The Islandora logger
+     */
+    public function __construct(GeminiClient $client,JwtAuth $jwt_auth, LoggerInterface $logger) {
+        $this->geminiClient = $client;
+        $this->jwtProvider = $jwt_auth;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Static creator.
+     *
+     * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+     *   The container
+     *
+     * @return \Drupal\islandora\Plugin\Field\GeminiLookup
+     */
+    public static function create(ContainerInterface $container) {
+        return new static(
+            $container->get('islandora.gemini_client'),
+            $container->get('jwt.authentication.jwt'),
+            $container->get('logger.channel.islandora')
+        );
+    }
+
+    /**
+     * Lookup this entity's URI in the Gemini db and return the other URI.
+     *
+     * @param \Drupal\Core\Entity\EntityInterface $entity
+     *   The entity to look for.
+     * @return string|null
+     *   Return the URI or null
+     * @throws \Drupal\Core\Entity\EntityMalformedException
+     *   If the entity cannot be converted to a URL.
+     */
+    public function lookup(EntityInterface $entity) {
+        if ($entity->id() != null) {
+            $drupal_uri = $entity->toUrl()->setAbsolute()->toString();
+            $drupal_uri .= '?_format=jsonld';
+            $token = "Bearer " . $this->jwtProvider->generateToken();
+            $linked_uri = $this->geminiClient->findByUri($drupal_uri, $token);
+            if (!is_null($linked_uri)) {
+                if (is_array($linked_uri)) {
+                    $linked_uri = reset($linked_uri);
+                }
+                return $linked_uri;
+            }
+        }
+        // Return null if we weren't in a saved entity or we didn't find a linked uri.
+        return null;
+    }
+
+}

--- a/src/GeminiLookup.php
+++ b/src/GeminiLookup.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Drupal\islandora;
 
 use Drupal\Core\Entity\EntityInterface;
@@ -8,83 +9,93 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Locates the matching Fedora URI from the Gemini database for use in a
- * pseudo field.
+ * Locates the matching Fedora URI from the Gemini database.
  *
  * @package Drupal\islandora
  */
 class GeminiLookup {
 
-    /**
-     * @var \Islandora\Crayfish\Commons\Client\GeminiClient
-     */
-    private $geminiClient;
+  /**
+   * A GeminiClient.
+   *
+   * @var \Islandora\Crayfish\Commons\Client\GeminiClient
+   */
+  private $geminiClient;
 
-    /**
-     * @var \Drupal\jwt\Authentication\Provider\JwtAuth
-     */
-    private $jwtProvider;
+  /**
+   * A JWT Provider service.
+   *
+   * @var \Drupal\jwt\Authentication\Provider\JwtAuth
+   */
+  private $jwtProvider;
 
-    /**
-     * @var \Psr\Log\LoggerInterface
-     */
-    private $logger;
+  /**
+   * The islandora logger channel.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  private $logger;
 
-    /**
-     * GeminiField constructor.
-     *
-     * @param \Islandora\Crayfish\Commons\Client\GeminiClient $client
-     *   The Gemini client
-     * @param \Psr\Log\LoggerInterface
-     *   The Islandora logger
-     */
-    public function __construct(GeminiClient $client,JwtAuth $jwt_auth, LoggerInterface $logger) {
-        $this->geminiClient = $client;
-        $this->jwtProvider = $jwt_auth;
-        $this->logger = $logger;
-    }
+  /**
+   * GeminiField constructor.
+   *
+   * @param \Islandora\Crayfish\Commons\Client\GeminiClient $client
+   *   The Gemini client.
+   * @param \Drupal\jwt\Authentication\Provider\JwtAuth $jwt_auth
+   *   The JWT provider.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   The Islandora logger.
+   */
+  public function __construct(GeminiClient $client, JwtAuth $jwt_auth, LoggerInterface $logger) {
+    $this->geminiClient = $client;
+    $this->jwtProvider = $jwt_auth;
+    $this->logger = $logger;
+  }
 
-    /**
-     * Static creator.
-     *
-     * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
-     *   The container
-     *
-     * @return \Drupal\islandora\Plugin\Field\GeminiLookup
-     */
-    public static function create(ContainerInterface $container) {
-        return new static(
-            $container->get('islandora.gemini_client'),
-            $container->get('jwt.authentication.jwt'),
-            $container->get('logger.channel.islandora')
-        );
-    }
+  /**
+   * Static creator.
+   *
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   *   The container.
+   *
+   * @return \Drupal\islandora\GeminiLookup
+   *   A GeminiLookup service.
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+        $container->get('islandora.gemini_client'),
+        $container->get('jwt.authentication.jwt'),
+        $container->get('logger.channel.islandora')
+    );
+  }
 
-    /**
-     * Lookup this entity's URI in the Gemini db and return the other URI.
-     *
-     * @param \Drupal\Core\Entity\EntityInterface $entity
-     *   The entity to look for.
-     * @return string|null
-     *   Return the URI or null
-     * @throws \Drupal\Core\Entity\EntityMalformedException
-     *   If the entity cannot be converted to a URL.
-     */
-    public function lookup(EntityInterface $entity) {
-        if ($entity->id() != null) {
-            $drupal_uri = $entity->toUrl()->setAbsolute()->toString();
-            $drupal_uri .= '?_format=jsonld';
-            $token = "Bearer " . $this->jwtProvider->generateToken();
-            $linked_uri = $this->geminiClient->findByUri($drupal_uri, $token);
-            if (!is_null($linked_uri)) {
-                if (is_array($linked_uri)) {
-                    $linked_uri = reset($linked_uri);
-                }
-                return $linked_uri;
-            }
+  /**
+   * Lookup this entity's URI in the Gemini db and return the other URI.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity to look for.
+   *
+   * @return string|null
+   *   Return the URI or null
+   *
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   *   If the entity cannot be converted to a URL.
+   */
+  public function lookup(EntityInterface $entity) {
+    if ($entity->id() != NULL) {
+      $drupal_uri = $entity->toUrl()->setAbsolute()->toString();
+      $drupal_uri .= '?_format=jsonld';
+      $token = "Bearer " . $this->jwtProvider->generateToken();
+      $linked_uri = $this->geminiClient->findByUri($drupal_uri, $token);
+      if (!is_null($linked_uri)) {
+        if (is_array($linked_uri)) {
+          $linked_uri = reset($linked_uri);
         }
-        // Return null if we weren't in a saved entity or we didn't find a linked uri.
-        return null;
+        return $linked_uri;
+      }
     }
+    // Return null if we weren't in a saved entity or we didn't find a uri.
+    return NULL;
+  }
 
 }

--- a/tests/src/Functional/IslandoraFunctionalTestBase.php
+++ b/tests/src/Functional/IslandoraFunctionalTestBase.php
@@ -5,11 +5,11 @@ namespace Drupal\Tests\islandora\Functional;
 use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\field\Tests\EntityReference\EntityReferenceTestTrait;
 use Drupal\link\LinkItemInterface;
 use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\field\Traits\EntityReferenceTestTrait;
+use Drupal\Tests\media\Traits\MediaTypeCreationTrait;
 use Drupal\Tests\TestFileCreationTrait;
-use Drupal\Tests\media\Functional\MediaFunctionalTestCreateMediaTypeTrait;
 
 /**
  * Base class for Functional tests.
@@ -18,7 +18,7 @@ class IslandoraFunctionalTestBase extends BrowserTestBase {
 
   use EntityReferenceTestTrait;
   use TestFileCreationTrait;
-  use MediaFunctionalTestCreateMediaTypeTrait;
+  use MediaTypeCreationTrait;
 
   protected static $modules = ['context_ui', 'field_ui', 'islandora'];
 
@@ -157,7 +157,7 @@ EOD;
     $this->createEntityReferenceField('node', 'test_type', 'field_tags', 'Tags', 'taxonomy_term', 'default', [], 2);
 
     // Create a media type.
-    $this->testMediaType = $this->createMediaType(['bundle' => 'test_media_type'], 'file');
+    $this->testMediaType = $this->createMediaType('file', ['id' => 'test_media_type']);
     $this->testMediaType->save();
     $this->createEntityReferenceField('media', $this->testMediaType->id(), 'field_media_of', 'Media Of', 'node', 'default', [], 2);
     $this->createEntityReferenceField('media', $this->testMediaType->id(), 'field_tags', 'Tags', 'taxonomy_term', 'default', [], 2);

--- a/tests/src/Functional/IslandoraSettingsFormTest.php
+++ b/tests/src/Functional/IslandoraSettingsFormTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Drupal\Tests\islandora\Functional;
+
+/**
+ * Class IslandoraSettingsFormTest.
+ *
+ * @package Drupal\Tests\islandora\Functional
+ * @group islandora
+ * @coversDefaultClass \Drupal\islandora\Form\IslandoraSettingsForm
+ */
+class IslandoraSettingsFormTest extends IslandoraFunctionalTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    // Create a test user.
+    $account = $this->drupalCreateUser([
+      'bypass node access',
+      'administer site configuration',
+      'view media',
+      'create media',
+      'update media',
+    ]);
+    $this->drupalLogin($account);
+  }
+
+  /**
+   * Test Gemini URL validation.
+   */
+  public function testGeminiUri() {
+    $this->drupalGet('/admin/config/islandora/core');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains("Gemini URL");
+    $this->assertSession()->fieldValueEquals('edit-gemini-url', '');
+
+    $this->drupalPostForm('admin/config/islandora/core', ['edit-gemini-url' => 'not_a_url'], t('Save configuration'));
+    $this->assertSession()->pageTextContainsOnce("Cannot parse URL not_a_url");
+
+    $this->drupalPostForm('admin/config/islandora/core', ['edit-gemini-url' => 'http://whaturl.bob'], t('Save configuration'));
+    $this->assertSession()->pageTextContainsOnce("Cannot connect to URL http://whaturl.bob");
+  }
+
+  /**
+   * Test block on choosing Pseudo field bundles without a Gemini URL.
+   */
+  public function testPseudoFieldBundles() {
+    $this->drupalGet('/admin/config/islandora/core');
+    $this->assertSession()->statusCodeEquals(200);
+
+    $this->drupalPostForm('admin/config/islandora/core', [
+      'gemini_pseudo_bundles[test_type:node]' => TRUE,
+    ], t('Save configuration'));
+    $this->assertSession()->pageTextContainsOnce("Must enter Gemini URL before selecting bundles to display a pseudo field on.");
+
+  }
+
+}

--- a/tests/src/Kernel/EventGeneratorTest.php
+++ b/tests/src/Kernel/EventGeneratorTest.php
@@ -5,7 +5,7 @@ namespace Drupal\Tests\islandora\Kernel;
 use Drupal\islandora\EventGenerator\EventGenerator;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
-use Drupal\simpletest\UserCreationTrait;
+use Drupal\Tests\user\Traits\UserCreationTrait;
 
 /**
  * Tests the EventGenerator default implementation.

--- a/tests/src/Kernel/GeminiClientFactoryTest.php
+++ b/tests/src/Kernel/GeminiClientFactoryTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Drupal\Tests\islandora\Kernel;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\islandora\GeminiClientFactory;
+use Islandora\Crayfish\Commons\Client\GeminiClient;
+use Prophecy\Argument;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class GeminiClientFactoryTest.
+ *
+ * @package Drupal\Tests\islandora\Kernel
+ * @group islandora
+ * @coversDefaultClass \Drupal\islandora\GeminiClientFactory
+ */
+class GeminiClientFactoryTest extends IslandoraKernelTestBase {
+
+  private $logger;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    $prophecy = $this->prophesize(LoggerInterface::class);
+    $prophecy->notice(Argument::any());
+    $this->logger = $prophecy->reveal();
+  }
+
+  /**
+   * @covers ::create
+   * @expectedException \Symfony\Component\HttpKernel\Exception\PreconditionFailedHttpException
+   */
+  public function testNoUrlBlank() {
+    $prophecy = $this->prophesize(ImmutableConfig::class);
+    $prophecy->get(Argument::any())->willReturn('');
+    $immutConfig = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(ConfigFactoryInterface::class);
+    $prophecy->get(Argument::any())->willReturn($immutConfig);
+    $configFactory = $prophecy->reveal();
+
+    GeminiClientFactory::create($configFactory, $this->logger);
+  }
+
+  /**
+   * @covers ::create
+   * @expectedException \Symfony\Component\HttpKernel\Exception\PreconditionFailedHttpException
+   */
+  public function testNoUrlNull() {
+    $prophecy = $this->prophesize(ImmutableConfig::class);
+    $prophecy->get(Argument::any())->willReturn(NULL);
+    $immutConfig = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(ConfigFactoryInterface::class);
+    $prophecy->get(Argument::any())->willReturn($immutConfig);
+    $configFactory = $prophecy->reveal();
+
+    GeminiClientFactory::create($configFactory, $this->logger);
+  }
+
+  /**
+   * @covers ::create
+   * @throws \Exception
+   */
+  public function testUrl() {
+    $prophecy = $this->prophesize(ImmutableConfig::class);
+    $prophecy->get(Argument::any())->willReturn('http://localhost:8000/gemini');
+    $immutConfig = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(ConfigFactoryInterface::class);
+    $prophecy->get(Argument::any())->willReturn($immutConfig);
+    $configFactory = $prophecy->reveal();
+
+    $this->assertInstanceOf(GeminiClient::class, GeminiClientFactory::create($configFactory, $this->logger));
+  }
+
+}

--- a/tests/src/Kernel/GeminiLookupTest.php
+++ b/tests/src/Kernel/GeminiLookupTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Drupal\Tests\islandora\Kernel;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Url;
+use Drupal\islandora\GeminiLookup;
+use Drupal\jwt\Authentication\Provider\JwtAuth;
+use Islandora\Crayfish\Commons\Client\GeminiClient;
+use Prophecy\Argument;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class GeminiLookupTest.
+ *
+ * @group islandora
+ * @coversDefaultClass \Drupal\islandora\GeminiLookup
+ */
+class GeminiLookupTest extends IslandoraKernelTestBase {
+
+  private $geminiLookup;
+
+  private $geminiClient;
+
+  private $jwtAuth;
+
+  private $logger;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+    $prophecy = $this->prophesize(JwtAuth::class);
+    $prophecy->generateToken()->willReturn("islandora");
+    $this->jwtAuth = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(LoggerInterface::class);
+    $this->logger = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(GeminiClient::class);
+    $prophecy->findByUri(Argument::any(), Argument::any())->willReturn(NULL);
+    $this->geminiClient = $prophecy->reveal();
+  }
+
+  /**
+   * @covers ::lookup
+   * @covers ::__construct
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   */
+  public function testEntityNotSaved() {
+    $prophecy = $this->prophesize(EntityInterface::class);
+    $prophecy->id()->willReturn(NULL);
+    $entity = $prophecy->reveal();
+    $this->geminiLookup = new GeminiLookup(
+        $this->geminiClient,
+        $this->jwtAuth,
+        $this->logger
+    );
+    $this->assertEquals(NULL, $this->geminiLookup->lookup($entity));
+  }
+
+  /**
+   * @covers ::lookup
+   * @covers ::__construct
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   */
+  public function testEntityNotFound() {
+    $prop1 = $this->prophesize(Url::class);
+    $prop1->toString()->willReturn("http://localhost:8000/node/456");
+
+    $prop2 = $this->prophesize(Url::class);
+    $prop2->setAbsolute()->willReturn($prop1->reveal());
+    $url = $prop2->reveal();
+
+    $prophecy = $this->prophesize(EntityInterface::class);
+    $prophecy->id()->willReturn(456);
+    $prophecy->toUrl()->willReturn($url);
+    $entity = $prophecy->reveal();
+
+    $this->geminiLookup = new GeminiLookup(
+        $this->geminiClient,
+        $this->jwtAuth,
+        $this->logger
+    );
+
+    $this->assertEquals(NULL, $this->geminiLookup->lookup($entity));
+  }
+
+  /**
+   * @covers ::lookup
+   * @covers ::__construct
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   */
+  public function testEntityFound() {
+    $prop1 = $this->prophesize(Url::class);
+    $prop1->toString()->willReturn("http://localhost:8000/node/456");
+
+    $prop2 = $this->prophesize(Url::class);
+    $prop2->setAbsolute()->willReturn($prop1->reveal());
+    $url = $prop2->reveal();
+
+    $prophecy = $this->prophesize(EntityInterface::class);
+    $prophecy->id()->willReturn(456);
+    $prophecy->toUrl()->willReturn($url);
+    $entity = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(GeminiClient::class);
+    $prophecy->findByUri(Argument::any(), Argument::any())->willReturn(["http://fedora:8080/some/uri"]);
+    $this->geminiClient = $prophecy->reveal();
+
+    $this->geminiLookup = new GeminiLookup(
+        $this->geminiClient,
+        $this->jwtAuth,
+        $this->logger
+    );
+
+    $this->assertEquals("http://fedora:8080/some/uri", $this->geminiLookup->lookup($entity));
+  }
+
+}

--- a/tests/src/Kernel/JwtEventSubscriberTest.php
+++ b/tests/src/Kernel/JwtEventSubscriberTest.php
@@ -7,7 +7,7 @@ use Drupal\jwt\Authentication\Event\JwtAuthValidEvent;
 use Drupal\jwt\Authentication\Event\JwtAuthValidateEvent;
 use Drupal\jwt\JsonWebToken\JsonWebToken;
 use Drupal\jwt\JsonWebToken\JsonWebTokenInterface;
-use Drupal\simpletest\UserCreationTrait;
+use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\core\Entity\EntityStorageInterface;
 use Drupal\islandora\EventSubscriber\JwtEventSubscriber;
 


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/881

# What does this Pull Request do?

Creates a pseudo field to display the linked URI from the Gemini database on the Drupal resource.

# What's new?

Create two new services, one is a GeminiClient (with factory) and one does the lookup from an entity.

Alters the Islandora Core Settings to allow for a Gemini URI (with some simple validation) and to select which node, media or taxononomy_terms can have the field displayed.

Uses two hooks in `islandora.module` to define the new fields and build them.

* Does this change require documentation to be updated? Maybe
* Does this change add any new dependencies? yes, change from chullo to crayfish-commons
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?

1. Build a claw-playbook.
1. Login and replace the existing islandora module directory with this branch.
1. Install crayfish-commons (should happen automatically once this is merged when we install the module).
    1. `cd /var/www/html/drupal`
    1. `composer require "islandora/crayfish-commons:^0.0"`
1. Go to the **Islandora Settings** and try adding various things to the Gemini URL, non-URLs should throw an error and URLs that are fake should throw an error.
1. Check off "Repository Item (node)" under "Bundles with Gemini URI Pseudo field"
1. Save the form.
1. Clear the cache (could not figure out a cache tag to resolve this)
1. Edit the field display for the Repository Item (Structure -> Content-Types -> Manage Display [for Repository Item]) and move the "Fedora URI" field where ever you want it.
1. Save the field display.
1. Create a new **Repository Item**.
1. Wait a couple seconds and then try reloading the item. If the field does not appear, try clearing the  cache again. This might be a separate task, how to trigger a cache clear once the async PUT occurs.
1. The **Fedora URI** field should appear and have a link to the associated item in Fedora.  This is stored in cache and not regenerated with each view.

# Additional Notes:
There are a couple caching issues that could make this better, but I was lost. 

1. Once you enable the field on a content or media type, it doesn't appear in the list of fields until you clear the cache. Even though when you request the field display page you get `Cache-Control: must-revalidate, no-cache, private` and `X-Drupal-Dynamic-Cache: UNCACHEABLE`.
1. Also I'm not sure how we might have the Drupal cache for a node cleared once it gets written to Fedora. Perhaps some small rest service that takes the entity type and id and clears the associated cache tags.

# Interested parties
@Islandora-CLAW/committers
