### PR TITLE
Media Fedora Uri Pseudo-Fields

### DIFF
--- a/islandora.services.yml
+++ b/islandora.services.yml
@@ -57,4 +57,4 @@ services:
     arguments: ['@config.factory', '@logger.channel.islandora']
   islandora.gemini.lookup:
     class: Drupal\islandora\GeminiLookup
-    arguments: ['@islandora.gemini.client', '@jwt.authentication.jwt', '@logger.channel.islandora']
+    arguments: ['@islandora.gemini.client', '@jwt.authentication.jwt', '@islandora.media_source_service', '@http_client', '@logger.channel.islandora']

--- a/src/GeminiLookup.php
+++ b/src/GeminiLookup.php
@@ -3,10 +3,14 @@
 namespace Drupal\islandora;
 
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\islandora\MediaSource\MediaSourceService;
 use Drupal\jwt\Authentication\Provider\JwtAuth;
+use GuzzleHttp\Psr7;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
 use Islandora\Crayfish\Commons\Client\GeminiClient;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * Locates the matching Fedora URI from the Gemini database.
@@ -30,6 +34,20 @@ class GeminiLookup {
   private $jwtProvider;
 
   /**
+   * A MediaSourceService.
+   *
+   * @var \Drupal\islandora\MediaSource\MediaSourceService
+   */
+  private $mediaSource;
+
+  /**
+   * An http client.
+   *
+   * @var \GuzzleHttp\Client
+   */
+  private $guzzle;
+
+  /**
    * The islandora logger channel.
    *
    * @var \Psr\Log\LoggerInterface
@@ -43,30 +61,25 @@ class GeminiLookup {
    *   The Gemini client.
    * @param \Drupal\jwt\Authentication\Provider\JwtAuth $jwt_auth
    *   The JWT provider.
+   * @param \Drupal\islandora\MediaSource\MediaSourceService $media_source
+   *   Media source service.
+   * @param \GuzzleHttp\Client $guzzle
+   *   Guzzle client.
    * @param \Psr\Log\LoggerInterface $logger
    *   The Islandora logger.
    */
-  public function __construct(GeminiClient $client, JwtAuth $jwt_auth, LoggerInterface $logger) {
+  public function __construct(
+    GeminiClient $client,
+    JwtAuth $jwt_auth,
+    MediaSourceService $media_source,
+    Client $guzzle,
+    LoggerInterface $logger
+  ) {
     $this->geminiClient = $client;
     $this->jwtProvider = $jwt_auth;
+    $this->mediaSource = $media_source;
+    $this->guzzle = $guzzle;
     $this->logger = $logger;
-  }
-
-  /**
-   * Static creator.
-   *
-   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
-   *   The container.
-   *
-   * @return \Drupal\islandora\GeminiLookup
-   *   A GeminiLookup service.
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-        $container->get('islandora.gemini_client'),
-        $container->get('jwt.authentication.jwt'),
-        $container->get('logger.channel.islandora')
-    );
   }
 
   /**
@@ -77,24 +90,72 @@ class GeminiLookup {
    *
    * @return string|null
    *   Return the URI or null
-   *
-   * @throws \Drupal\Core\Entity\EntityMalformedException
-   *   If the entity cannot be converted to a URL.
    */
   public function lookup(EntityInterface $entity) {
-    if ($entity->id() != NULL) {
-      $drupal_uri = $entity->toUrl()->setAbsolute()->toString();
-      $drupal_uri .= '?_format=jsonld';
-      $token = "Bearer " . $this->jwtProvider->generateToken();
-      $linked_uri = $this->geminiClient->findByUri($drupal_uri, $token);
-      if (!is_null($linked_uri)) {
-        if (is_array($linked_uri)) {
-          $linked_uri = reset($linked_uri);
-        }
-        return $linked_uri;
+    // Exit early if the entity hasn't been saved yet.
+    if ($entity->id() == NULL) {
+      return NULL;
+    }
+
+    $is_media = $entity->getEntityTypeId() == 'media';
+
+    // Use the entity's uuid unless it's a media,
+    // use its file's uuid instead.
+    if ($is_media) {
+      try {
+        $file = $this->mediaSource->getSourceFile($entity);
+        $uuid = $file->uuid();
+      }
+      // If the media has no source file, exit early.
+      catch (NotFoundHttpException $e) {
+        return NULL;
       }
     }
-    // Return null if we weren't in a saved entity or we didn't find a uri.
+    else {
+      $uuid = $entity->uuid();
+    }
+
+    // Look it up in Gemini.
+    $token = "Bearer " . $this->jwtProvider->generateToken();
+    $urls = $this->geminiClient->getUrls($uuid, $token);
+
+    // Exit early if there's no results from Gemini.
+    if (empty($urls)) {
+      return NULL;
+    }
+
+    // If it's not a media, just return the url from Gemini;.
+    if (!$is_media) {
+      return $urls['fedora'];
+    }
+
+    // If it's a media, perform a HEAD request against
+    // the file in Fedora and get its 'describedy' link header.
+    try {
+      $head = $this->guzzle->head(
+        $urls['fedora'],
+        ['allow_redirects' => FALSE, 'headers' => ['Authorization' => $token]]
+      );
+      $links = Psr7\parse_header($head->getHeader("Link"));
+      foreach ($links as $link) {
+        if ($link['rel'] == 'describedby') {
+          return trim($link[0], '<>');
+        }
+      }
+    }
+    catch (RequestException $e) {
+      $this->logger->warn(
+        "Error performing Gemini lookup for media. Fedora HEAD to @url returned @status => @message",
+        [
+          '@url' => $urls['fedora'],
+          '@status' => $e->getCode(),
+          '@message' => $e->getMessage,
+        ]
+      );
+      return NULL;
+    }
+
+    // Return null if no link header is found.
     return NULL;
   }
 

--- a/tests/src/Kernel/GeminiLookupTest.php
+++ b/tests/src/Kernel/GeminiLookupTest.php
@@ -3,12 +3,17 @@
 namespace Drupal\Tests\islandora\Kernel;
 
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Url;
+use Drupal\file\FileInterface;
+use Drupal\media\MediaInterface;
 use Drupal\islandora\GeminiLookup;
+use Drupal\islandora\MediaSource\MediaSourceService;
 use Drupal\jwt\Authentication\Provider\JwtAuth;
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
 use Islandora\Crayfish\Commons\Client\GeminiClient;
 use Prophecy\Argument;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * Class GeminiLookupTest.
@@ -17,10 +22,6 @@ use Psr\Log\LoggerInterface;
  * @coversDefaultClass \Drupal\islandora\GeminiLookup
  */
 class GeminiLookupTest extends IslandoraKernelTestBase {
-
-  private $geminiLookup;
-
-  private $geminiClient;
 
   private $jwtAuth;
 
@@ -32,90 +33,265 @@ class GeminiLookupTest extends IslandoraKernelTestBase {
   public function setUp() {
     parent::setUp();
     $prophecy = $this->prophesize(JwtAuth::class);
-    $prophecy->generateToken()->willReturn("islandora");
     $this->jwtAuth = $prophecy->reveal();
 
     $prophecy = $this->prophesize(LoggerInterface::class);
     $this->logger = $prophecy->reveal();
-
-    $prophecy = $this->prophesize(GeminiClient::class);
-    $prophecy->findByUri(Argument::any(), Argument::any())->willReturn(NULL);
-    $this->geminiClient = $prophecy->reveal();
   }
 
   /**
    * @covers ::lookup
    * @covers ::__construct
-   * @throws \Drupal\Core\Entity\EntityMalformedException
    */
   public function testEntityNotSaved() {
     $prophecy = $this->prophesize(EntityInterface::class);
     $prophecy->id()->willReturn(NULL);
     $entity = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(GeminiClient::class);
+    $gemini_client = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(MediaSourceService::class);
+    $media_source = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(Client::class);
+    $guzzle = $prophecy->reveal();
+
     $this->geminiLookup = new GeminiLookup(
-        $this->geminiClient,
+        $gemini_client,
         $this->jwtAuth,
+        $media_source,
+        $guzzle,
         $this->logger
     );
+
     $this->assertEquals(NULL, $this->geminiLookup->lookup($entity));
   }
 
   /**
    * @covers ::lookup
    * @covers ::__construct
-   * @throws \Drupal\Core\Entity\EntityMalformedException
    */
   public function testEntityNotFound() {
-    $prop1 = $this->prophesize(Url::class);
-    $prop1->toString()->willReturn("http://localhost:8000/node/456");
-
-    $prop2 = $this->prophesize(Url::class);
-    $prop2->setAbsolute()->willReturn($prop1->reveal());
-    $url = $prop2->reveal();
-
     $prophecy = $this->prophesize(EntityInterface::class);
-    $prophecy->id()->willReturn(456);
-    $prophecy->toUrl()->willReturn($url);
-    $entity = $prophecy->reveal();
-
-    $this->geminiLookup = new GeminiLookup(
-        $this->geminiClient,
-        $this->jwtAuth,
-        $this->logger
-    );
-
-    $this->assertEquals(NULL, $this->geminiLookup->lookup($entity));
-  }
-
-  /**
-   * @covers ::lookup
-   * @covers ::__construct
-   * @throws \Drupal\Core\Entity\EntityMalformedException
-   */
-  public function testEntityFound() {
-    $prop1 = $this->prophesize(Url::class);
-    $prop1->toString()->willReturn("http://localhost:8000/node/456");
-
-    $prop2 = $this->prophesize(Url::class);
-    $prop2->setAbsolute()->willReturn($prop1->reveal());
-    $url = $prop2->reveal();
-
-    $prophecy = $this->prophesize(EntityInterface::class);
-    $prophecy->id()->willReturn(456);
-    $prophecy->toUrl()->willReturn($url);
+    $prophecy->id()->willReturn(1);
+    $prophecy->getEntityTypeId()->willReturn('node');
+    $prophecy->uuid()->willReturn('abc123');
     $entity = $prophecy->reveal();
 
     $prophecy = $this->prophesize(GeminiClient::class);
-    $prophecy->findByUri(Argument::any(), Argument::any())->willReturn(["http://fedora:8080/some/uri"]);
-    $this->geminiClient = $prophecy->reveal();
+    $prophecy->getUrls(Argument::any(), Argument::any())
+      ->willReturn([]);
+    $gemini_client = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(MediaSourceService::class);
+    $media_source = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(Client::class);
+    $guzzle = $prophecy->reveal();
 
     $this->geminiLookup = new GeminiLookup(
-        $this->geminiClient,
+        $gemini_client,
         $this->jwtAuth,
+        $media_source,
+        $guzzle,
         $this->logger
     );
 
-    $this->assertEquals("http://fedora:8080/some/uri", $this->geminiLookup->lookup($entity));
+    $this->assertEquals(NULL, $this->geminiLookup->lookup($entity));
+  }
+
+  /**
+   * @covers ::lookup
+   * @covers ::__construct
+   */
+  public function testEntityFound() {
+    $prophecy = $this->prophesize(EntityInterface::class);
+    $prophecy->id()->willReturn(1);
+    $prophecy->getEntityTypeId()->willReturn('node');
+    $prophecy->uuid()->willReturn('abc123');
+    $entity = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(GeminiClient::class);
+    $prophecy->getUrls(Argument::any(), Argument::any())
+      ->willReturn(['drupal' => '', 'fedora' => 'http://localhost:8080/fcrepo/rest/abc123']);
+    $gemini_client = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(MediaSourceService::class);
+    $media_source = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(Client::class);
+    $guzzle = $prophecy->reveal();
+
+    $this->geminiLookup = new GeminiLookup(
+        $gemini_client,
+        $this->jwtAuth,
+        $media_source,
+        $guzzle,
+        $this->logger
+    );
+
+    $this->assertEquals(
+      'http://localhost:8080/fcrepo/rest/abc123',
+      $this->geminiLookup->lookup($entity)
+    );
+  }
+
+  /**
+   * @covers ::lookup
+   * @covers ::__construct
+   */
+  public function testMediaHasNoSourceFile() {
+    $prophecy = $this->prophesize(MediaInterface::class);
+    $prophecy->id()->willReturn(1);
+    $prophecy->getEntityTypeId()->willReturn('media');
+    $prophecy->uuid()->willReturn('abc123');
+    $entity = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(GeminiClient::class);
+    $gemini_client = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(MediaSourceService::class);
+    $prophecy->getSourceFile(Argument::any())
+      ->willThrow(new NotFoundHttpException("Media has no source"));
+    $media_source = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(Client::class);
+    $guzzle = $prophecy->reveal();
+
+    $this->geminiLookup = new GeminiLookup(
+        $gemini_client,
+        $this->jwtAuth,
+        $media_source,
+        $guzzle,
+        $this->logger
+    );
+
+    $this->assertEquals(NULL, $this->geminiLookup->lookup($entity));
+  }
+
+  /**
+   * @covers ::lookup
+   * @covers ::__construct
+   */
+  public function testMediaNotFound() {
+    $prophecy = $this->prophesize(MediaInterface::class);
+    $prophecy->id()->willReturn(1);
+    $prophecy->getEntityTypeId()->willReturn('media');
+    $prophecy->uuid()->willReturn('abc123');
+    $entity = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(FileInterface::class);
+    $prophecy->uuid()->willReturn('xyzpdq');
+    $file = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(MediaSourceService::class);
+    $prophecy->getSourceFile(Argument::any())
+      ->willReturn($file);
+    $media_source = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(GeminiClient::class);
+    $prophecy->getUrls(Argument::any(), Argument::any())
+      ->willReturn([]);
+    $gemini_client = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(Client::class);
+    $guzzle = $prophecy->reveal();
+
+    $this->geminiLookup = new GeminiLookup(
+        $gemini_client,
+        $this->jwtAuth,
+        $media_source,
+        $guzzle,
+        $this->logger
+    );
+
+    $this->assertEquals(NULL, $this->geminiLookup->lookup($entity));
+  }
+
+  /**
+   * @covers ::lookup
+   * @covers ::__construct
+   */
+  public function testFileFoundButNoDescribedby() {
+    $prophecy = $this->prophesize(MediaInterface::class);
+    $prophecy->id()->willReturn(1);
+    $prophecy->getEntityTypeId()->willReturn('media');
+    $prophecy->uuid()->willReturn('abc123');
+    $entity = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(FileInterface::class);
+    $prophecy->uuid()->willReturn('xyzpdq');
+    $file = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(MediaSourceService::class);
+    $prophecy->getSourceFile(Argument::any())
+      ->willReturn($file);
+    $media_source = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(GeminiClient::class);
+    $prophecy->getUrls(Argument::any(), Argument::any())
+      ->willReturn(['drupal' => '', 'fedora' => 'http://localhost:8080/fcrepo/rest/xyzpdq']);
+    $gemini_client = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(Client::class);
+    $prophecy->head(Argument::any(), Argument::any())
+      ->willReturn(new Response(200, []));
+    $guzzle = $prophecy->reveal();
+
+    $this->geminiLookup = new GeminiLookup(
+        $gemini_client,
+        $this->jwtAuth,
+        $media_source,
+        $guzzle,
+        $this->logger
+    );
+
+    $this->assertEquals(NULL, $this->geminiLookup->lookup($entity));
+  }
+
+  /**
+   * @covers ::lookup
+   * @covers ::__construct
+   */
+  public function testMediaFound() {
+    $prophecy = $this->prophesize(MediaInterface::class);
+    $prophecy->id()->willReturn(1);
+    $prophecy->getEntityTypeId()->willReturn('media');
+    $prophecy->uuid()->willReturn('abc123');
+    $entity = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(FileInterface::class);
+    $prophecy->uuid()->willReturn('xyzpdq');
+    $file = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(MediaSourceService::class);
+    $prophecy->getSourceFile(Argument::any())
+      ->willReturn($file);
+    $media_source = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(GeminiClient::class);
+    $prophecy->getUrls(Argument::any(), Argument::any())
+      ->willReturn(['drupal' => '', 'fedora' => 'http://localhost:8080/fcrepo/rest/xyzpdq']);
+    $gemini_client = $prophecy->reveal();
+
+    $prophecy = $this->prophesize(Client::class);
+    $prophecy->head(Argument::any(), Argument::any())
+      ->willReturn(new Response(200, ['Link' => '<http://localhost:8080/fcrepo/rest/xyzpdq/fcr:metadata>; rel="describedby"']));
+    $guzzle = $prophecy->reveal();
+
+    $this->geminiLookup = new GeminiLookup(
+        $gemini_client,
+        $this->jwtAuth,
+        $media_source,
+        $guzzle,
+        $this->logger
+    );
+
+    $this->assertEquals(
+      'http://localhost:8080/fcrepo/rest/xyzpdq/fcr:metadata',
+      $this->geminiLookup->lookup($entity)
+    );
   }
 
 }


### PR DESCRIPTION
**GitHub Issue**: 
- Resolves https://github.com/Islandora-CLAW/CLAW/issues/881
- Resolves https://github.com/Islandora-CLAW/CLAW/issues/1109
- Follow up to https://github.com/Islandora-CLAW/islandora/pull/124

# What does this Pull Request do?

Adds the Fedora Uri pseudo-field to Media.

# What's new?
Looks up media in addition to other entity types in the GeminiLookup class.  This is done by issuing a HEAD request against the binary in Fedora to find it's `rel="describedby"` link header.

# How should this be tested?

- Pull down this PR
- Clear your cache
- You should now see the Fedora Uri pseudo-field on Media entities
![Screenshot from 2019-05-02 12-20-03](https://user-images.githubusercontent.com/20773151/57086549-b5c58c80-6cd4-11e9-9f99-f8edd5597b07.png)


@Islandora-CLAW/committers
