### PR TITLE
Allow multiple view modes

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -374,7 +374,11 @@ function islandora_entity_extra_field_info() {
  * Implements hook_entity_view().
  */
 function islandora_entity_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
-  if ($view_mode == 'full') {
+  $route_match_item = \Drupal::routeMatch()->getParameters()->all();
+  // Get the parameter, which might be node, media or taxonomy term.
+  $current_entity = reset($route_match_item);
+  // Match exactly to ensure they are the same entity type too.
+  if ($entity === $current_entity) {
     if ($display->getComponent('field_gemini_uri')) {
       $gemini = \Drupal::service('islandora.gemini.lookup');
       if ($gemini instanceof GeminiLookup) {


### PR DESCRIPTION
**GitHub Issue**: n/a

Related to: Islandora-CLAW/CLAW#881

# What does this Pull Request do?

Previous work assumed a "full" view mode, but if you enable the OpenSeadragon viewer you end up in the "open_seadragon" view mode and the field is not displayed.

I couldn't just remove the if statement as when you view a "repository item" you hit the `hook_entity_view` 3 times, once for the node, once for the user and once for the media (service file image). So you'd end up with more than one Fedora URI displayed.

This PR gets the current "entity" from the route and ensures that we only display the Fedora URI for that item entity. So node on the node page, media on the media page, etc.

# What's new?

* Does this change require documentation to be updated? no
* Does this change add any new dependencies?  no
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?

-- Before this PR
Create a Repository Item with Image type.
Save and clear the cache.
See the Fedora URI.
Edit the Repository Item and enable the "Open Seadragon" display hint.
Save (you shouldn't have to clear the cache)
See the Fedora URI disappear.

-- After this PR
The Fedora URI displays when using the Open Seadragon display hint.

Probably also helps the PDF JS display hint.

# Interested parties
@Islandora-CLAW/committers
