### PR TITLE
Adding model for Digital Documents (e.g. pdf)

### DIFF
--- a/migrate/tags.csv
+++ b/migrate/tags.csv
@@ -11,3 +11,4 @@ islandora_models,"Binary","A generic binary file for repository items that don't
 islandora_models,"Collection","A collection is an aggregation of items",http://purl.org/dc/dcmitype/Collection
 islandora_models,"Image","A visual representation other than text, including all types of moving image and still image",http://purl.org/coar/resource_type/c_c513
 islandora_models,"Video","A recording of visual images, usually in motion and with sound accompaniment",http://purl.org/coar/resource_type/c_12ce
+islandora_models,"Digital Document","An electronic file or document.",https://schema.org/DigitalDocument


### PR DESCRIPTION
**GitHub Issue**: 
- Part of https://github.com/Islandora-CLAW/CLAW/issues/1111
- Required by https://github.com/Islandora-CLAW/islandora_demo/pull/28

# What does this Pull Request do?

Gives PDFs their own model so that they can be differentiated from other binaries during derivative generation.

# What's new?
A taxonomy term for schema:DigitalDocument

# How should this be tested?

https://github.com/Islandora-Devops/claw-playbook/pull/105

# Interested parties
@Islandora-CLAW/committers
