### PR TITLE
Breadcrumbs sub-module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,8 @@ install:
   - cd web; drush --uri=127.0.0.1:8282 en -y islandora
 
 script:
-  - $SCRIPT_DIR/line_endings.sh $TRAVIS_BUILD_DIR
-  - phpcs --standard=Drupal --ignore=*.md --extensions=php,module,inc,install,test,profile,theme,css,info $TRAVIS_BUILD_DIR
-  - phpcpd --names *.module,*.inc,*.test,*.php $TRAVIS_BUILD_DIR
-  - php core/scripts/run-tests.sh --suppress-deprecations --url http://127.0.0.1:8282 --verbose --php `which php` --module "islandora"
+  - $SCRIPT_DIR/travis_scripts.sh
+  - $SCRIPT_DIR/run-tests.sh "islandora_breadcrumbs"
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ install:
 
 script:
   - $SCRIPT_DIR/travis_scripts.sh
+  - $SCRIPT_DIR/run-tests.sh "islandora"
   - $SCRIPT_DIR/run-tests.sh "islandora_breadcrumbs"
 
 notifications:

--- a/modules/islandora_breadcrumbs/config/install/islandora.breadcrumbs.yml
+++ b/modules/islandora_breadcrumbs/config/install/islandora.breadcrumbs.yml
@@ -1,0 +1,3 @@
+maxDepth: -1
+includeSelf: FALSE
+referenceField: field_member_of

--- a/modules/islandora_breadcrumbs/config/schema/islandora_breadcrumbs.schema.yml
+++ b/modules/islandora_breadcrumbs/config/schema/islandora_breadcrumbs.schema.yml
@@ -1,0 +1,12 @@
+islandora.breadcrumbs:
+  type: config_object
+  mapping:
+    maxDepth:
+      type: integer
+      label: 'Max Depth'
+    includeSelf:
+      type: boolean
+      label: 'Include Self'
+    referenceField:
+      type: string
+      label: 'Reference Field'

--- a/modules/islandora_breadcrumbs/islandora_breadcrumbs.info.yml
+++ b/modules/islandora_breadcrumbs/islandora_breadcrumbs.info.yml
@@ -1,0 +1,7 @@
+name: 'Islandora Breadcrumbs'
+type: module
+description: 'Builds breadcrumbs based on field_member_of relationships.'
+core: 8.x
+package: Islandora
+dependencies:
+  - islandora

--- a/modules/islandora_breadcrumbs/islandora_breadcrumbs.services.yml
+++ b/modules/islandora_breadcrumbs/islandora_breadcrumbs.services.yml
@@ -1,0 +1,5 @@
+services:
+  islandora_breadcrumbs.breadcrumb:
+    class: Drupal\islandora_breadcrumbs\IslandoraBreadcrumbBuilder
+    tags:
+      - { name: breadcrumb_builder, priority: 100 }

--- a/modules/islandora_breadcrumbs/islandora_breadcrumbs.services.yml
+++ b/modules/islandora_breadcrumbs/islandora_breadcrumbs.services.yml
@@ -1,5 +1,6 @@
 services:
   islandora_breadcrumbs.breadcrumb:
     class: Drupal\islandora_breadcrumbs\IslandoraBreadcrumbBuilder
+    arguments: ['@config.factory']
     tags:
       - { name: breadcrumb_builder, priority: 100 }

--- a/modules/islandora_breadcrumbs/src/IslandoraBreadcrumbBuilder.php
+++ b/modules/islandora_breadcrumbs/src/IslandoraBreadcrumbBuilder.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Drupal\islandora_breadcrumbs;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Breadcrumb\Breadcrumb;
+use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Provides a breadcrumb builder for nodes using field_member_of.
+ */
+class IslandoraBreadcrumbBuilder implements BreadcrumbBuilderInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies(RouteMatchInterface $attributes) {
+    $parameters = $attributes->getParameters()->all();
+    if (!empty($parameters['node'])) {
+      return ($parameters['node']->hasField('field_member_of') &&
+              !$parameters['node']->field_member_of->isEmpty());
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(RouteMatchInterface $route_match) {
+    $node = $route_match->getParameter('node');
+    $breadcrumb = new Breadcrumb();
+    $chain = IslandoraBreadcrumbBuilder::walkMembership($node);
+
+    // Don't include the current item. @TODO make configurable.
+    array_pop($chain);
+    $breadcrumb->addCacheableDependency($node);
+
+    // Add membership chain to the breadcrumb.
+    foreach ($chain as $chainlink) {
+      $breadcrumb->addCacheableDependency($chainlink);
+      $breadcrumb->addLink($chainlink->toLink());
+    }
+    $breadcrumb->addCacheContexts(['route']);
+    return $breadcrumb;
+  }
+
+  /**
+   * Follows chain of field_member_of links.
+   */
+  protected static function walkMembership(EntityInterface $entity) {
+    if ($entity->hasField('field_member_of') &&
+      !$entity->get('field_member_of')->isEmpty()) {
+      $crumbs = IslandoraBreadcrumbBuilder::walkMembership($entity->get('field_member_of')->entity);
+      $crumbs[] = $entity;
+      return $crumbs;
+    }
+    return [$entity];
+  }
+
+}

--- a/modules/islandora_breadcrumbs/tests/src/Functional/BreadcrumbsTest.php
+++ b/modules/islandora_breadcrumbs/tests/src/Functional/BreadcrumbsTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Drupal\Tests\islandora_breadcrumbs\Functional;
+
+use Drupal\Tests\islandora\Functional\IslandoraFunctionalTestBase;
+use Drupal\Tests\system\Functional\Menu\AssertBreadcrumbTrait;
+
+/**
+ * Tests the Islandora Breadcrumbs Builder.
+ *
+ * @group islandora_breadcrumbs
+ */
+class BreadcrumbsTest extends IslandoraFunctionalTestBase {
+
+  use AssertBreadcrumbTrait;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'islandora_breadcrumbs',
+  ];
+
+
+  protected $nodeA;
+
+  protected $nodeB;
+
+  protected $nodeC;
+
+  protected $nodeD;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    // Create some nodes.
+    $this->nodeA = $this->container->get('entity_type.manager')->getStorage('node')->create([
+      'type' => $this->testType->id(),
+      'title' => 'Node A',
+    ]);
+    $this->nodeA->save();
+
+    $this->nodeB = $this->container->get('entity_type.manager')->getStorage('node')->create([
+      'type' => $this->testType->id(),
+      'title' => 'Node B',
+    ]);
+    $this->nodeB->set('field_member_of', [$this->nodeA->id()]);
+    $this->nodeB->save();
+
+    $this->nodeC = $this->container->get('entity_type.manager')->getStorage('node')->create([
+      'type' => $this->testType->id(),
+      'title' => 'Node C',
+    ]);
+    $this->nodeC->set('field_member_of', [$this->nodeB->id()]);
+    $this->nodeC->save();
+
+    $this->nodeD = $this->container->get('entity_type.manager')->getStorage('node')->create([
+      'type' => $this->testType->id(),
+      'title' => 'Node D',
+    ]);
+    $this->nodeD->set('field_member_of', [$this->nodeC->id()]);
+    $this->nodeD->save();
+  }
+
+  /**
+   * @covers \Drupal\islandora_breadcrumbs\IslandoraBreadcrumbBuilder::applies
+   */
+  public function testDefaults() {
+    $breadcrumbs = [
+      $this->nodeC->toUrl()->toString() => $this->nodeC->label(),
+      $this->nodeB->toUrl()->toString() => $this->nodeB->label(),
+      $this->nodeA->toUrl()->toString() => $this->nodeA->label(),
+    ];
+    $this->assertBreadcrumb($this->nodeD->toUrl()->toString(), $breadcrumbs);
+
+    // Create a reference loop.
+    $this->nodeA->set('field_member_of', [$this->nodeD->id()]);
+    $this->nodeA->save();
+
+    // We should still escape it and have the same trail as before.
+    $this->assertBreadcrumb($this->nodeD->toUrl()->toString(), $breadcrumbs);
+  }
+
+}


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1141

# What does this Pull Request do?

Provides an islandora_breadcrumb submodule. The breadcrumbs are created by following the field_member_of chain from the current node until it runs out of links.

# What's new?
* Added the islandora_breadcrumbs submodule.
* Does this change require documentation to be updated? We could add some....
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? No, it is completely optional and only impacts other breadcrumb settings you may have.

# How should this be tested?

* Make a collection
* Make a sub-collection belonging to the first collection (repeat as often as you would like)
* Make an item belonging to any of those collections
* Be sad that the item has no breadcrumbs.
* Apply the PR
* Enable the Islandora Breadcrumbs module (e.g. `drush en-y islandora_breadcrumbs`)
* Flush caches
* View the item
* Rejoice, for there are breadcrumbs!

# Additional Notes

We could add some configuration to it later, but this will probably be fine for now.

# Interested parties
@Islandora-CLAW/committers
