### PR TITLE
Respecting jsonld module configuration for ?_format=jsonld

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "drupal/context": "^4.0",
     "drupal/search_api": "~1.8",
-    "islandora/jsonld": "dev-8.x-1.x",
+    "islandora/jsonld": "dev-issue-887",
     "stomp-php/stomp-php": "4.*",
     "drupal/jwt": "1.0.0-alpha6",
     "drupal/filehash": "^1.1",

--- a/src/ContextReaction/NormalizerAlterReaction.php
+++ b/src/ContextReaction/NormalizerAlterReaction.php
@@ -3,7 +3,11 @@
 namespace Drupal\islandora\ContextReaction;
 
 use Drupal\context\ContextReactionPluginBase;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\jsonld\Form\JsonLdSettingsForm;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Base class to alter the normalizes Json-ld.
@@ -12,10 +16,41 @@ use Drupal\Core\Entity\EntityInterface;
  *
  * @package Drupal\islandora\ContextReaction
  */
-abstract class NormalizerAlterReaction extends ContextReactionPluginBase {
+abstract class NormalizerAlterReaction extends ContextReactionPluginBase implements ContainerFactoryPluginInterface {
 
   /**
-   * This reaction takes can alter the array of json-ld built from the entity.
+   * The configuration.
+   *
+   * @var \Drupal\Core\Config\ImmutableConfig
+   */
+  protected $jsonldConfig;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration,
+                              $plugin_id,
+                              $plugin_definition,
+                              ConfigFactoryInterface $config_factory) {
+
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->jsonldConfig = $config_factory->get(JsonLdSettingsForm::CONFIG_NAME);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * This reaction can alter the array of json-ld built from the entity.
    *
    * @param \Drupal\Core\Entity\EntityInterface|null $entity
    *   The entity we are normalizing.
@@ -25,5 +60,22 @@ abstract class NormalizerAlterReaction extends ContextReactionPluginBase {
    *   The context used in the normalizer.
    */
   abstract public function execute(EntityInterface $entity = NULL, array &$normalized = NULL, array $context = NULL);
+
+  /**
+   * Helper function to get the url for an entity that repsects jsonld config.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity.
+   *
+   * @return string
+   *   The url.
+   */
+  protected function getSubjectUrl(EntityInterface $entity) {
+    $url = $entity->toUrl('canonical', ['absolute' => TRUE]);
+    if (!$this->jsonldConfig->get(JsonLdSettingsForm::REMOVE_JSONLD_FORMAT)) {
+      $url->setRouteParameter('_format', 'jsonld');
+    }
+    return $url->toString();
+  }
 
 }

--- a/src/Plugin/ContextReaction/JsonldTypeAlterReaction.php
+++ b/src/Plugin/ContextReaction/JsonldTypeAlterReaction.php
@@ -43,7 +43,7 @@ class JsonldTypeAlterReaction extends NormalizerAlterReaction {
 
     // Search for the entity in the graph.
     foreach ($normalized['@graph'] as &$elem) {
-      if ($elem['@id'] === $entity->toUrl()->setAbsolute()->toString() . '?_format=jsonld') {
+      if ($elem['@id'] === $this->getSubjectUrl($entity)) {
         foreach ($entity->get($config['source_field'])->getValue() as $type) {
           // If the configured field is using an entity reference,
           // we will see if it uses the core config's field_external_uri.

--- a/src/Plugin/ContextReaction/MappingUriPredicateReaction.php
+++ b/src/Plugin/ContextReaction/MappingUriPredicateReaction.php
@@ -2,9 +2,9 @@
 
 namespace Drupal\islandora\Plugin\ContextReaction;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\islandora\ContextReaction\NormalizerAlterReaction;
 use Drupal\islandora\MediaSource\MediaSourceService;
 use Drupal\jsonld\Normalizer\NormalizerBase;
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   label = @Translation("Map URI to predicate")
  * )
  */
-class MappingUriPredicateReaction extends NormalizerAlterReaction implements ContainerFactoryPluginInterface {
+class MappingUriPredicateReaction extends NormalizerAlterReaction {
 
   const URI_PREDICATE = 'drupal_uri_predicate';
 
@@ -28,8 +28,18 @@ class MappingUriPredicateReaction extends NormalizerAlterReaction implements Con
   /**
    * {@inheritdoc}
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, MediaSourceService $media_source) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  public function __construct(array $configuration,
+                              $plugin_id,
+                              $plugin_definition,
+                              ConfigFactoryInterface $config_factory,
+                              MediaSourceService $media_source) {
+
+    parent::__construct(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $config_factory
+    );
     $this->mediaSource = $media_source;
   }
 
@@ -41,6 +51,7 @@ class MappingUriPredicateReaction extends NormalizerAlterReaction implements Con
       $configuration,
       $plugin_id,
       $plugin_definition,
+      $container->get('config.factory'),
       $container->get('islandora.media_source_service')
     );
   }
@@ -59,10 +70,7 @@ class MappingUriPredicateReaction extends NormalizerAlterReaction implements Con
     $config = $this->getConfiguration();
     $drupal_predicate = $config[self::URI_PREDICATE];
     if (!is_null($drupal_predicate) && !empty($drupal_predicate)) {
-      $url = $entity
-        ->toUrl('canonical', ['absolute' => TRUE])
-        ->setRouteParameter('_format', 'jsonld')
-        ->toString();
+      $url = $this->getSubjectUrl($entity);
       if ($context['needs_jsonldcontext'] === FALSE) {
         $drupal_predicate = NormalizerBase::escapePrefix($drupal_predicate, $context['namespaces']);
       }


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/887

Goes with
- https://github.com/Islandora-CLAW/jsonld/pull/32
- https://github.com/Islandora-CLAW/Crayfish/pull/65


# What does this Pull Request do?

Forces our jsonld alters to respect the `jsonld` module's configuration for stripping out `?_format=jsonld` from urls.

# What's new?

The jsonld module's configuration is injected into our base class for altering jsonld using context.  There's a helper function implemented in the base class that generates the appropriate url to use when searching the jsonld graph for the entity in question.

# How should this be tested?

See https://github.com/Islandora-CLAW/CLAW/issues/887

# Interested parties
@Islandora-CLAW/committers
