### PR TITLE
Swapping file and media urls in jsonld

### DIFF
--- a/src/Plugin/ContextReaction/MappingUriPredicateReaction.php
+++ b/src/Plugin/ContextReaction/MappingUriPredicateReaction.php
@@ -77,9 +77,10 @@ class MappingUriPredicateReaction extends NormalizerAlterReaction {
       if (isset($normalized['@graph']) && is_array($normalized['@graph'])) {
         foreach ($normalized['@graph'] as &$graph) {
           if (isset($graph['@id']) && $graph['@id'] == $url) {
+            // Swap media and file urls.
             if ($entity instanceof MediaInterface) {
               $file = $this->mediaSource->getSourceFile($entity);
-              $url = $file->url('canonical', ['absolute' => TRUE]);
+              $graph['@id'] = $file->url('canonical', ['absolute' => TRUE]);
             }
             if (isset($graph[$drupal_predicate])) {
               if (!is_array($graph[$drupal_predicate])) {


### PR DESCRIPTION
**GitHub Issue**: Resolves https://github.com/Islandora-CLAW/CLAW/issues/662

Requires https://github.com/Islandora-CLAW/islandora_demo/pull/29 and https://github.com/Islandora-CLAW/Crayfish/pull/68

# What does this Pull Request do?

Swaps media and file urls when altering jsonld with `MappingUriPredicateReaction`.

# What's new?

One line change and a test to confirm its behaviour.

# How should this be tested?

- Make a media and view it's ?_format=jsonld route, you should see something like this (edited for brevity):
```json
{
   "@graph":[
      {
         "@id":"http://localhost:8000/media/1",
         "@type":[
            "http://pcdm.org/models#File",
            "http://pcdm.org/use#OriginalFile"
         ],
         ...
         "http://schema.org/sameAs":[
            {
               "@value":"http://localhost:8000/_flysystem/fedora/2019-05/Flemming-Magic.jpg"
            }
         ]
      },
      ...
   ]
}
```
- Pull changes from https://github.com/Islandora-CLAW/islandora_demo/pull/29 into `islandora_demo`
- Pull changes from https://github.com/Islandora-CLAW/Crayfish/pull/68 into Crayfish
- Pull changes from this PR into `islandora`
- `drush -y fim islandora_demo`
- `drush cr`
- View the ?_format=jsonld route again, and this time you should see
```json
{
   "@graph":[
      {
         "@id":"http://localhost:8000/_flysystem/fedora/2019-05/Flemming-Magic.jpg",
         "@type":[
            "http://pcdm.org/models#File",
            "http://pcdm.org/use#OriginalFile"
         ],
         ...
         "http://www.iana.org/assignments/relation/describedby":[
            {
               "@value":"http://localhost:8000/media/1"
            }
         ]
      },
      ...
   ]
}
```
- Curl the resource in Fedora, and you should see something like this (again, edited for brevity):
```
@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix iana:  <http://www.iana.org/assignments/relation/> .

<http://localhost:8080/fcrepo/rest/2019-05/Flemming-Magic.jpg>
        rdf:type                    fedora:NonRdfSourceDescription ;
        rdf:type                    <http://pcdm.org/models#File> ;
        rdf:type                    <http://pcdm.org/use#OriginalFile> ;
        rdf:type                    fedora:Binary ;
        rdf:type                    fedora:Resource ;
        rdf:type                    ldp:NonRDFSource ;
        iana:describedby            "http://localhost:8000/media/4" ;
        iana:describedby            <http://localhost:8080/fcrepo/rest/2019-05/Flemming-Magic.jpg/fcr:metadata> ;
```  
- Confirm triplestore indexing by issuing a query similar to this.  Note that you have to use the file's url and not the media's.
```
SELECT ?s ?p ?o WHERE { <http://localhost:8000/_flysystem/fedora/2019-05/Flemming-Magic.jpg> ?p ?o }
```

# Interested parties
@Islandora-CLAW/committers
