### PR TITLE
Forcing flysystem downloads to be language neutral

### DIFF
--- a/src/Flysystem/Fedora.php
+++ b/src/Flysystem/Fedora.php
@@ -136,4 +136,5 @@ class Fedora implements FlysystemPluginInterface, ContainerFactoryPluginInterfac
       ['absolute' => TRUE, 'language' => $undefined]
     )->toString();
   }
+
 }

--- a/src/Flysystem/Fedora.php
+++ b/src/Flysystem/Fedora.php
@@ -4,6 +4,7 @@ namespace Drupal\islandora\Flysystem;
 
 use Drupal\Core\Logger\RfcLogLevel;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Url;
 use Drupal\flysystem\Plugin\FlysystemPluginInterface;
 use Drupal\flysystem\Plugin\FlysystemUrlTrait;
 use Drupal\islandora\Flysystem\Adapter\FedoraAdapter;
@@ -116,4 +117,23 @@ class Fedora implements FlysystemPluginInterface, ContainerFactoryPluginInterfac
     return [];
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getExternalUrl($uri) {
+    $path = str_replace('\\', '/', $this->getTarget($uri));
+
+    $arguments = [
+      'scheme' => $this->getScheme($uri),
+      'filepath' => $path,
+    ];
+
+    // Force file urls to be language neutral.
+    $undefined = \Drupal::languageManager()->getLanguage('und');
+    return Url::fromRoute(
+      'flysystem.serve',
+      $arguments,
+      ['absolute' => TRUE, 'language' => $undefined]
+    )->toString();
+  }
 }


### PR DESCRIPTION
**GitHub Issue**: Resolves https://github.com/Islandora-CLAW/CLAW/issues/985

# What does this Pull Request do?

Forces flysystem downloads from Fedora to be language neutral.  This prevents the language prefix from getting jammed into the url.

# What's new?
An overridden getExternalUrl() method that forces the language to be Undefined (und).

# How should this be tested?

- Make a second language and set one to default 
- Go visit a media that you put in Fedora, and its file's url should have the language prefix in it, e.g. `http://localhost:8000/en/_flysystem/fedora/2019-05/blah.jpg`
- Pull in this PR
- Clear the cache
- Go visit the same media, and now the language prefix should be gone, e.g. `http://localhost:8000/_flysystem/fedora/2019-05/blah.jpg`

# Interested parties
@kanasznagyzoltan @rangel35 @DonRichards @Islandora-CLAW/committers
