### PR TITLE
Set default settings

### DIFF
--- a/config/install/islandora.settings.yml
+++ b/config/install/islandora.settings.yml
@@ -1,0 +1,4 @@
+broker_url: 'tcp://localhost:61613'
+jwt_expiry: '+2 hour'
+gemini_url: ''
+gemini_pseudo_bundles: []

--- a/islandora.module
+++ b/islandora.module
@@ -356,7 +356,7 @@ function islandora_entity_extra_field_info() {
   $config_factory = \Drupal::service('config.factory')->get(IslandoraSettingsForm::CONFIG_NAME);
   $extra_field = [];
 
-  $pseudo_bundles = $config_factory->get(IslandoraSettingsForm::GEMINI_PSEUDO) ? $config_factory->get(IslandoraSettingsForm::GEMINI_PSEUDO) : [];
+  $pseudo_bundles = $config_factory->get(IslandoraSettingsForm::GEMINI_PSEUDO);
 
   foreach ($pseudo_bundles as $key) {
     list($bundle, $content_entity) = explode(":", $key);

--- a/src/Form/IslandoraSettingsForm.php
+++ b/src/Form/IslandoraSettingsForm.php
@@ -80,22 +80,22 @@ class IslandoraSettingsForm extends ConfigFormBase {
     $form[self::BROKER_URL] = [
       '#type' => 'textfield',
       '#title' => $this->t('Broker URL'),
-      '#default_value' => $config->get(self::BROKER_URL) ? $config->get(self::BROKER_URL) : 'tcp://localhost:61613',
+      '#default_value' => $config->get(self::BROKER_URL),
     ];
 
     $form[self::JWT_EXPIRY] = [
       '#type' => 'textfield',
       '#title' => $this->t('JWT Expiry'),
-      '#default_value' => $config->get(self::JWT_EXPIRY) ? $config->get(self::JWT_EXPIRY) : '+2 hour',
+      '#default_value' => $config->get(self::JWT_EXPIRY),
     ];
 
     $form[self::GEMINI_URL] = [
       '#type' => 'textfield',
       '#title' => $this->t('Gemini URL'),
-      '#default_value' => $config->get(self::GEMINI_URL) ? $config->get(self::GEMINI_URL) : '',
+      '#default_value' => $config->get(self::GEMINI_URL),
     ];
 
-    $selected_bundles = $config->get(self::GEMINI_PSEUDO) ? $config->get(self::GEMINI_PSEUDO) : [];
+    $selected_bundles = $config->get(self::GEMINI_PSEUDO);
 
     $options = [];
     foreach (['node', 'media', 'taxonomy_term'] as $content_entity) {


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1129

# What does this Pull Request do?

Instead of embedded defaults this creates a default configuration object, which allows us to modify the settings in the claw-playbook post-install.yml

# What's new?
Replace defaults in code and checks (as there will now be some value provided)

* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?

I made an islandora_demo branch to call this branch. So to test, pull a clean claw-playbook. 
Then make this change
```
diff --git a/inventory/vagrant/group_vars/webserver/drupal.yml b/inventory/vagrant/group_vars/webserver/drupal.yml
index 76d1870..5bc09ae 100644
--- a/inventory/vagrant/group_vars/webserver/drupal.yml
+++ b/inventory/vagrant/group_vars/webserver/drupal.yml
@@ -16,7 +16,7 @@ drupal_composer_dependencies:
   - "drupal/pdf:1.x-dev"
   - "islandora/carapace:dev-8.x-1.x"
   - "islandora/openseadragon:dev-8.x-1.x"
-  - "islandora/islandora_demo:dev-8.x-1.x"
+  - "islandora/islandora_demo:dev-issue-1129"
 drupal_composer_project_package: "islandora/drupal-project:8.6.10"
 drupal_composer_project_options: "--prefer-dist --stability dev --no-interaction"
 drupal_core_path: "{{ drupal_composer_install_dir }}/web"
```
and do a vagrant up. At the end you can ensure that the appropriate defaults are still set.

# Interested parties
@Islandora-CLAW/committers
