### PR TITLE
Switch @value to @id

### DIFF
--- a/src/Plugin/ContextReaction/MappingUriPredicateReaction.php
+++ b/src/Plugin/ContextReaction/MappingUriPredicateReaction.php
@@ -91,7 +91,7 @@ class MappingUriPredicateReaction extends NormalizerAlterReaction {
                 $tmp = $graph[$drupal_predicate];
                 $graph[$drupal_predicate] = [$tmp];
               }
-              elseif (array_search($url, array_column($graph[$drupal_predicate], '@value'))) {
+              elseif (array_search($url, array_column($graph[$drupal_predicate], '@id'))) {
                 // Don't add it if it already exists.
                 return;
               }
@@ -99,7 +99,7 @@ class MappingUriPredicateReaction extends NormalizerAlterReaction {
             else {
               $graph[$drupal_predicate] = [];
             }
-            $graph[$drupal_predicate][] = ["@value" => $url];
+            $graph[$drupal_predicate][] = ["@id" => $url];
             return;
           }
         }

--- a/tests/src/Functional/MappingUriPredicateReactionTest.php
+++ b/tests/src/Functional/MappingUriPredicateReactionTest.php
@@ -107,7 +107,7 @@ class MappingUriPredicateReactionTest extends IslandoraFunctionalTestBase {
     );
     $this->assertEquals(
       "$url?_format=jsonld",
-      $json['@graph'][0]['http://www.w3.org/2002/07/owl#sameAs'][0]['@value'],
+      $json['@graph'][0]['http://www.w3.org/2002/07/owl#sameAs'][0]['@id'],
       'Missing alter added predicate.'
     );
 
@@ -129,7 +129,7 @@ class MappingUriPredicateReactionTest extends IslandoraFunctionalTestBase {
       $json['@graph'][0], 'Still has old predicate');
     $this->assertEquals(
       "$url?_format=jsonld",
-      $json['@graph'][0]['http://example.org/first/second'][0]['@value'],
+      $json['@graph'][0]['http://example.org/first/second'][0]['@id'],
       'Missing alter added predicate.'
     );
   }
@@ -181,7 +181,7 @@ class MappingUriPredicateReactionTest extends IslandoraFunctionalTestBase {
     $json = \GuzzleHttp\json_decode($new_contents, TRUE);
     $this->assertEquals(
       "$media_url?_format=jsonld",
-      $json['@graph'][0]['http://www.iana.org/assignments/relation/describedby'][0]['@value'],
+      $json['@graph'][0]['http://www.iana.org/assignments/relation/describedby'][0]['@id'],
       'Missing alter added predicate.'
     );
     $this->assertEquals(


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1131

# What does this Pull Request do?

Swaps the `@value` for a `@id` in the JSON-LD of the mappingUriPredicate Content reaction.

# What's new?

* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?

1. Create Repository Item without this PR.
1. View the `?_format=jsonld` of your resource, notice the 
     ```
     "http:\/\/schema.org\/sameAs":[{"@value":"http:\/\/localhost:8000\/node\/1"}]
     ```
1. Pull in this PR, clear cache and view `?_format=jsonld` again
     ```
     "http:\/\/schema.org\/sameAs":[{"@id":"http:\/\/localhost:8000\/node\/1"}]
     ```

# Interested parties
@Islandora-CLAW/committers and @dannylamb 
