### PR TITLE
Fixes content translation

### DIFF
--- a/islandora.services.yml
+++ b/islandora.services.yml
@@ -3,6 +3,7 @@
 services:
   islandora.eventgenerator:
     class: Drupal\islandora\EventGenerator\EventGenerator
+    arguments: ['@language_manager']
   islandora.stomp:
     class: Stomp\StatefulStomp
     factory: ['Drupal\islandora\StompFactory', create]

--- a/src/Flysystem/Fedora.php
+++ b/src/Flysystem/Fedora.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\islandora\Flysystem;
 
+use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Logger\RfcLogLevel;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Url;
@@ -31,19 +32,30 @@ class Fedora implements FlysystemPluginInterface, ContainerFactoryPluginInterfac
   protected $mimeTypeGuesser;
 
   /**
+   * Language manager.
+   *
+   * @var \Drupal\Core\Language\LanguageManagerInterface
+   */
+  protected $languageManager;
+
+  /**
    * Constructs a Fedora plugin for Flysystem.
    *
    * @param \Islandora\Chullo\IFedoraApi $fedora
    *   Fedora client.
    * @param \Symfony\Component\HttpFoundation\File\Mimetype\MimeTypeGuesserInterface $mime_type_guesser
    *   Mimetype guesser.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   *   Language manager.
    */
   public function __construct(
     IFedoraApi $fedora,
-    MimeTypeGuesserInterface $mime_type_guesser
+    MimeTypeGuesserInterface $mime_type_guesser,
+    LanguageManagerInterface $language_manager
   ) {
     $this->fedora = $fedora;
     $this->mimeTypeGuesser = $mime_type_guesser;
+    $this->languageManager = $language_manager;
   }
 
   /**
@@ -63,7 +75,8 @@ class Fedora implements FlysystemPluginInterface, ContainerFactoryPluginInterfac
     // Return it.
     return new static(
       $fedora,
-      $container->get('file.mime_type.guesser')
+      $container->get('file.mime_type.guesser'),
+      $container->get('language_manager')
     );
   }
 
@@ -129,7 +142,7 @@ class Fedora implements FlysystemPluginInterface, ContainerFactoryPluginInterfac
     ];
 
     // Force file urls to be language neutral.
-    $undefined = \Drupal::languageManager()->getLanguage('und');
+    $undefined = $this->languageManager->getLanguage('und');
     return Url::fromRoute(
       'flysystem.serve',
       $arguments,

--- a/tests/src/Kernel/EventGeneratorTest.php
+++ b/tests/src/Kernel/EventGeneratorTest.php
@@ -64,7 +64,7 @@ class EventGeneratorTest extends IslandoraKernelTestBase {
     $this->entity->save();
 
     // Create the event generator so we can test it.
-    $this->eventGenerator = new EventGenerator();
+    $this->eventGenerator = new EventGenerator($this->container->get('language_manager'));
   }
 
   /**

--- a/tests/src/Kernel/FedoraPluginTest.php
+++ b/tests/src/Kernel/FedoraPluginTest.php
@@ -31,7 +31,9 @@ class FedoraPluginTest extends IslandoraKernelTestBase {
 
     $mime_guesser = $this->prophesize(MimeTypeGuesserInterface::class)->reveal();
 
-    return new Fedora($api, $mime_guesser);
+    $language_manager = $this->container->get('language_manager');
+
+    return new Fedora($api, $mime_guesser, $language_manager);
   }
 
   /**

--- a/tests/src/Kernel/IslandoraKernelTestBase.php
+++ b/tests/src/Kernel/IslandoraKernelTestBase.php
@@ -54,6 +54,7 @@ abstract class IslandoraKernelTestBase extends KernelTestBase {
     $this->installEntitySchema('context');
     $this->installEntitySchema('file');
     $this->installConfig('filter');
+    $this->installConfig('rest');
   }
 
 }


### PR DESCRIPTION
**GitHub Issue**: Resolves https://github.com/Islandora-CLAW/CLAW/issues/1127

# What does this Pull Request do?

The same fix for https://github.com/Islandora-CLAW/islandora/pull/137, but applied to urls getting put into messages on their way to the queue.  This may also partially resolve issues arising from https://github.com/Islandora-CLAW/CLAW/issues/1095.  At least this same pattern will have to be repeated (read: put into utility function and just call that).

# What's new?
Forcing URLs to be language neutral.  Plus some minor refactoring to properly inject the language manager.

# How should this be tested?

Confirm Original Behaviour:
- Add a language to turn on content translation (I added French)
- Make a node
- Click its translate tab
- Add a translation (again, French for me)
- Save the translation
- Go check out the node in the triplestore and fedora, there's no French metadata.

Confirm fixed behaviour
- Pull in this PR
- `drush cr`
- Go edit the translation and save it
- Go check out the node in the triplestore and fedora, and you should see both French and English metadata.

# Interested parties
@Islandora-CLAW/committers
