### PR TITLE
use common testing scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,8 @@ install:
   - cd web; drush --uri=127.0.0.1:8282 en -y islandora
 
 script:
-  - $SCRIPT_DIR/line_endings.sh $TRAVIS_BUILD_DIR
-  - phpcs --standard=Drupal --ignore=*.md --extensions=php,module,inc,install,test,profile,theme,css,info $TRAVIS_BUILD_DIR
-  - phpcpd --names *.module,*.inc,*.test,*.php $TRAVIS_BUILD_DIR
-  - php core/scripts/run-tests.sh --suppress-deprecations --url http://127.0.0.1:8282 --verbose --php `which php` --module "islandora"
+  - $SCRIPT_DIR/travis_scripts.sh
+  - $SCRIPT_DIR/run-tests.sh "islandora"
 
 notifications:
   irc:


### PR DESCRIPTION
**GitHub Issue**: n/a

Relies on https://github.com/Islandora-CLAW/CLAW/pull/1146

To make enabling testing on sub-modules easier, as in https://github.com/Islandora-CLAW/islandora/pull/132

# What does this Pull Request do?

Calls the scripts added to the main CLAW `.scripts` directory.

# What's new?

* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?

This will fail Travis until https://github.com/Islandora-CLAW/CLAW/pull/1146 is merged, then restarting the travis build should pass.

# Interested parties
@Islandora-CLAW/committers
