### PR TITLE
Change field_media_use cardinality

### DIFF
--- a/modules/islandora_core_feature/config/install/field.storage.media.field_media_use.yml
+++ b/modules/islandora_core_feature/config/install/field.storage.media.field_media_use.yml
@@ -12,7 +12,7 @@ settings:
   target_type: taxonomy_term
 module: core
 locked: false
-cardinality: 1
+cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1142

# What does this Pull Request do?

Changes the cardinality of field_media_use from '1' to ''-1' allowing a media to have multiple uses (e.g. OriginalFile AND ServiceFile). 

# What's new?

* Changes `islandora/modules/islandora_core_feature/config/install/field.storage.media.field_media_use.yml`'s cardinality from '1' to '-1' 
* Does this change require documentation to be updated? Maybe...
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? No! `\0/`
* Could this change impact execution of existing code? No. Everything miraculously still works.

# How should this be tested?

* Apply the PR (to a site with content or an empty site, doesn't matter which).
* Import the change to islandora_core_feature: `drush fim -y islandora_core_feature`
* Create an item and upload a media with both 'Original File' and 'Service File' selected. (Works best with something like a PDF.)
* Wait for the derivatives fire (should happen fairly quickly, especially if testing a Jpeg or PDF).
* Check the item's media, it should only have two: the media you created (listing it both as an 'Original File' and a 'Service File') and a thumbnail (if a PDF or video, we don't have audio thumbnails).

# Additional Notes

Optionally test with https://github.com/Islandora-CLAW/islandora_defaults/pull/2 which changes the select box on field_media_use from a select box to checkboxes.

# Interested parties
@dannylamb, @Islandora-CLAW/committers
