### PR TITLE
Refactoring URL generation into util functions

### DIFF
--- a/islandora.services.yml
+++ b/islandora.services.yml
@@ -3,7 +3,7 @@
 services:
   islandora.eventgenerator:
     class: Drupal\islandora\EventGenerator\EventGenerator
-    arguments: ['@language_manager', '@islandora.media_source_service']
+    arguments: ['@islandora.utils', '@islandora.media_source_service']
   islandora.stomp:
     class: Stomp\StatefulStomp
     factory: ['Drupal\islandora\StompFactory', create]
@@ -16,12 +16,12 @@ services:
       - { name: event_subscriber }
   islandora.media_link_header_subscriber:
     class: Drupal\islandora\EventSubscriber\MediaLinkHeaderSubscriber
-    arguments: ['@entity_type.manager', '@entity_field.manager', '@access_manager', '@current_user', '@current_route_match', '@request_stack', '@language_manager']
+    arguments: ['@entity_type.manager', '@entity_field.manager', '@access_manager', '@current_user', '@current_route_match', '@request_stack', '@islandora.utils']
     tags:
       - { name: event_subscriber }
   islandora.node_link_header_subscriber:
     class: Drupal\islandora\EventSubscriber\NodeLinkHeaderSubscriber
-    arguments: ['@entity_type.manager', '@entity_field.manager', '@access_manager', '@current_user', '@current_route_match', '@request_stack', '@language_manager', '@islandora.utils']
+    arguments: ['@entity_type.manager', '@entity_field.manager', '@access_manager', '@current_user', '@current_route_match', '@request_stack', '@islandora.utils']
     tags:
       - { name: event_subscriber }
   islandora.admin_view_route_subscriber:
@@ -51,7 +51,7 @@ services:
     arguments: ['@entity_type.manager', '@current_user', '@language_manager', '@entity.query', '@file_system', '@islandora.utils']
   islandora.utils:
     class: Drupal\islandora\IslandoraUtils
-    arguments: ['@entity_type.manager', '@entity_field.manager', '@entity.query', '@context.manager', '@flysystem_factory']
+    arguments: ['@entity_type.manager', '@entity_field.manager', '@entity.query', '@context.manager', '@flysystem_factory', '@language_manager']
   islandora.gemini.client:
     class: Islandora\Crayfish\Commons\Client\GeminiClient
     factory: ['Drupal\islandora\GeminiClientFactory', create]

--- a/modules/islandora_audio/tests/src/Functional/GenerateAudioDerivativeTest.php
+++ b/modules/islandora_audio/tests/src/Functional/GenerateAudioDerivativeTest.php
@@ -11,6 +11,9 @@ use Drupal\Tests\islandora\Functional\GenerateDerivativeTestBase;
  */
 class GenerateAudioDerivativeTest extends GenerateDerivativeTestBase {
 
+  /**
+   * {@inheritdoc}
+   */
   protected static $modules = ['context_ui', 'islandora_audio'];
 
   /**

--- a/modules/islandora_breadcrumbs/tests/src/Functional/BreadcrumbsTest.php
+++ b/modules/islandora_breadcrumbs/tests/src/Functional/BreadcrumbsTest.php
@@ -24,12 +24,32 @@ class BreadcrumbsTest extends IslandoraFunctionalTestBase {
   ];
 
 
+  /**
+   * A node.
+   *
+   * @var \Drupal\node\NodeInterface
+   */
   protected $nodeA;
 
+  /**
+   * Another node.
+   *
+   * @var \Drupal\node\NodeInterface
+   */
   protected $nodeB;
 
+  /**
+   * Yet another node.
+   *
+   * @var \Drupal\node\NodeInterface
+   */
   protected $nodeC;
 
+  /**
+   * Another one.
+   *
+   * @var \Drupal\node\NodeInterface
+   */
   protected $nodeD;
 
   /**

--- a/modules/islandora_image/tests/src/Functional/GenerateImageDerivativeTest.php
+++ b/modules/islandora_image/tests/src/Functional/GenerateImageDerivativeTest.php
@@ -11,6 +11,9 @@ use Drupal\Tests\islandora\Functional\GenerateDerivativeTestBase;
  */
 class GenerateImageDerivativeTest extends GenerateDerivativeTestBase {
 
+  /**
+   * {@inheritdoc}
+   */
   protected static $modules = ['context_ui', 'islandora_image'];
 
   /**

--- a/modules/islandora_video/tests/src/Functional/GenerateVideoDerivativeTest.php
+++ b/modules/islandora_video/tests/src/Functional/GenerateVideoDerivativeTest.php
@@ -11,6 +11,9 @@ use Drupal\Tests\islandora\Functional\GenerateDerivativeTestBase;
  */
 class GenerateVideoDerivativeTest extends GenerateDerivativeTestBase {
 
+  /**
+   * {@inheritdoc}
+   */
   protected static $modules = ['context_ui', 'islandora_video'];
 
   /**

--- a/src/ContextReaction/NormalizerAlterReaction.php
+++ b/src/ContextReaction/NormalizerAlterReaction.php
@@ -7,6 +7,7 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\jsonld\Form\JsonLdSettingsForm;
+use Drupal\islandora\IslandoraUtils;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -26,15 +27,24 @@ abstract class NormalizerAlterReaction extends ContextReactionPluginBase impleme
   protected $jsonldConfig;
 
   /**
+   * Islandora utils.
+   *
+   * @var \Drupal\islandora\IslandoraUtils
+   */
+  protected $utils;
+
+  /**
    * {@inheritdoc}
    */
   public function __construct(array $configuration,
                               $plugin_id,
                               $plugin_definition,
-                              ConfigFactoryInterface $config_factory) {
+                              ConfigFactoryInterface $config_factory,
+                              IslandoraUtils $utils) {
 
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->jsonldConfig = $config_factory->get(JsonLdSettingsForm::CONFIG_NAME);
+    $this->utils = $utils;
   }
 
   /**
@@ -45,7 +55,8 @@ abstract class NormalizerAlterReaction extends ContextReactionPluginBase impleme
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('config.factory')
+      $container->get('config.factory'),
+      $container->get('islandora.utils')
     );
   }
 
@@ -71,11 +82,11 @@ abstract class NormalizerAlterReaction extends ContextReactionPluginBase impleme
    *   The url.
    */
   protected function getSubjectUrl(EntityInterface $entity) {
-    $url = $entity->toUrl('canonical', ['absolute' => TRUE]);
+    $format = '';
     if (!$this->jsonldConfig->get(JsonLdSettingsForm::REMOVE_JSONLD_FORMAT)) {
-      $url->setRouteParameter('_format', 'jsonld');
+      $format = 'jsonld';
     }
-    return $url->toString();
+    return $this->utils->getRestUrl($entity, $format);
   }
 
 }

--- a/src/Controller/MediaSourceController.php
+++ b/src/Controller/MediaSourceController.php
@@ -11,6 +11,7 @@ use Drupal\media\MediaInterface;
 use Drupal\media\MediaTypeInterface;
 use Drupal\node\NodeInterface;
 use Drupal\taxonomy\TermInterface;
+use Drupal\islandora\IslandoraUtils;
 use Drupal\islandora\MediaSource\MediaSourceService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -40,19 +41,30 @@ class MediaSourceController extends ControllerBase {
   protected $database;
 
   /**
+   * Islandora utils.
+   *
+   * @var \Drupal\islandora\IslandoraUtils
+   */
+  protected $utils;
+
+  /**
    * MediaSourceController constructor.
    *
    * @param \Drupal\islandora\MediaSource\MediaSourceService $service
    *   Service for business logic.
    * @param \Drupal\Core\Database\Connection $database
    *   Database connection.
+   * @param \Drupal\islandora\IslandoraUtils $utils
+   *   Islandora utils.
    */
   public function __construct(
     MediaSourceService $service,
-    Connection $database
+    Connection $database,
+    IslandoraUtils $utils
   ) {
     $this->service = $service;
     $this->database = $database;
+    $this->utils = $utils;
   }
 
   /**
@@ -67,7 +79,8 @@ class MediaSourceController extends ControllerBase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('islandora.media_source_service'),
-      $container->get('database')
+      $container->get('database'),
+      $container->get('islandora.utils')
     );
   }
 
@@ -162,7 +175,7 @@ class MediaSourceController extends ControllerBase {
       // We return the media if it was newly created.
       if ($media) {
         $response = new Response("", 201);
-        $response->headers->set("Location", $media->url('canonical', ['absolute' => TRUE]));
+        $response->headers->set("Location", $this->utils->getEntityUrl($media));
       }
       else {
         $response = new Response("", 204);

--- a/src/EventSubscriber/MediaLinkHeaderSubscriber.php
+++ b/src/EventSubscriber/MediaLinkHeaderSubscriber.php
@@ -77,10 +77,9 @@ class MediaLinkHeaderSubscriber extends LinkHeaderSubscriber implements EventSub
     }
 
     // Collect file links for the media.
-    $undefined = $this->languageManager->getLanguage('und');
     foreach ($media->get($source_field)->referencedEntities() as $referencedEntity) {
       if ($referencedEntity->access('view')) {
-        $file_url = $referencedEntity->url('canonical', ['absolute' => TRUE, 'language' => $undefined]);
+        $file_url = $this->utils->getDownloadUrl($referencedEntity);
         $links[] = "<$file_url>; rel=\"describes\"; type=\"{$referencedEntity->getMimeType()}\"";
       }
     }

--- a/src/EventSubscriber/NodeLinkHeaderSubscriber.php
+++ b/src/EventSubscriber/NodeLinkHeaderSubscriber.php
@@ -2,17 +2,8 @@
 
 namespace Drupal\islandora\EventSubscriber;
 
-use Drupal\Core\Access\AccessManagerInterface;
-use Drupal\Core\Entity\EntityFieldManager;
-use Drupal\Core\Entity\EntityTypeManager;
-use Drupal\Core\Language\LanguageManagerInterface;
-use Drupal\Core\Routing\RouteMatchInterface;
-use Drupal\Core\Session\AccountInterface;
-use Drupal\Core\Url;
-use Drupal\islandora\IslandoraUtils;
 use Drupal\node\NodeInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -21,55 +12,6 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  * @package Drupal\islandora\EventSubscriber
  */
 class NodeLinkHeaderSubscriber extends LinkHeaderSubscriber implements EventSubscriberInterface {
-
-  /**
-   * Derivative utils.
-   *
-   * @var \Drupal\islandora\IslandoraUtils
-   */
-  protected $utils;
-
-  /**
-   * Constructor.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\Core\Entity\EntityFieldManager $entity_field_manager
-   *   The entity field manager.
-   * @param \Drupal\Core\Access\AccessManagerInterface $access_manager
-   *   The access manager.
-   * @param \Drupal\Core\Session\AccountInterface $account
-   *   The current user.
-   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
-   *   The route match object.
-   * @param Symfony\Component\HttpFoundation\RequestStack $request_stack
-   *   Request stack (for current request).
-   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
-   *   Language manager.
-   * @param \Drupal\islandora\IslandoraUtils $utils
-   *   Derivative utils.
-   */
-  public function __construct(
-    EntityTypeManager $entity_type_manager,
-    EntityFieldManager $entity_field_manager,
-    AccessManagerInterface $access_manager,
-    AccountInterface $account,
-    RouteMatchInterface $route_match,
-    RequestStack $request_stack,
-    LanguageManagerInterface $language_manager,
-    IslandoraUtils $utils
-  ) {
-    parent::__construct(
-      $entity_type_manager,
-      $entity_field_manager,
-      $access_manager,
-      $account,
-      $route_match,
-      $request_stack,
-      $language_manager
-    );
-    $this->utils = $utils;
-  }
 
   /**
    * Adds node-specific link headers to appropriate responses.
@@ -105,13 +47,8 @@ class NodeLinkHeaderSubscriber extends LinkHeaderSubscriber implements EventSubs
    */
   protected function generateRelatedMediaLinks(NodeInterface $node) {
     $links = [];
-    $undefined = $this->languageManager->getLanguage('und');
     foreach ($this->utils->getMedia($node) as $media) {
-      $url = Url::fromRoute(
-        "rest.entity.media.GET",
-        ['media' => $media->id()],
-        ['absolute' => TRUE, 'language' => $undefined]
-      )->toString();
+      $url = $this->utils->getEntityUrl($media);
       foreach ($media->referencedEntities() as $term) {
         if ($term->getEntityTypeId() == 'taxonomy_term' && $term->hasField('field_external_uri')) {
           $field = $term->get('field_external_uri');

--- a/src/Flysystem/Adapter/FedoraAdapter.php
+++ b/src/Flysystem/Adapter/FedoraAdapter.php
@@ -20,7 +20,18 @@ class FedoraAdapter implements AdapterInterface {
   use StreamedCopyTrait;
   use NotSupportingVisibilityTrait;
 
+  /**
+   * Fedora client.
+   *
+   * @var \Islandora\Chullo\IFedoraApi
+   */
   protected $fedora;
+
+  /**
+   * Mimetype guesser.
+   *
+   * @var \Symfony\Component\HttpFoundation\File\Mimetype\MimeTypeGuesserInterface
+   */
   protected $mimeTypeGuesser;
 
   /**
@@ -75,7 +86,6 @@ class FedoraAdapter implements AdapterInterface {
 
     $meta = $this->getMetadataFromHeaders($response);
     $meta['path'] = $path;
-
     if ($meta['type'] == 'file') {
       $meta['stream'] = StreamWrapper::getResource($response->getBody());
     }

--- a/src/Flysystem/Fedora.php
+++ b/src/Flysystem/Fedora.php
@@ -27,8 +27,18 @@ class Fedora implements FlysystemPluginInterface, ContainerFactoryPluginInterfac
 
   use FlysystemUrlTrait;
 
+  /**
+   * Fedora client.
+   *
+   * @var \Islandora\Chullo\IFedoraApi
+   */
   protected $fedora;
 
+  /**
+   * Mimetype guesser.
+   *
+   * @var \Symfony\Component\HttpFoundation\File\Mimetype\MimeTypeGuesserInterface
+   */
   protected $mimeTypeGuesser;
 
   /**

--- a/src/Plugin/Action/AbstractGenerateDerivative.php
+++ b/src/Plugin/Action/AbstractGenerateDerivative.php
@@ -155,7 +155,7 @@ class AbstractGenerateDerivative extends EmitEvent {
       throw new \RuntimeException("Could not locate source file for media {$source_media->id()}", 500);
     }
 
-    $data['source_uri'] = $source_file->url('canonical', ['absolute' => TRUE]);
+    $data['source_uri'] = $this->utils->getDownloadUrl($source_file);
 
     // Find the term for the derivative and use it to set the destination url
     // in the data array.

--- a/src/Plugin/ContextReaction/MappingUriPredicateReaction.php
+++ b/src/Plugin/ContextReaction/MappingUriPredicateReaction.php
@@ -24,6 +24,11 @@ class MappingUriPredicateReaction extends NormalizerAlterReaction {
 
   const URI_PREDICATE = 'drupal_uri_predicate';
 
+  /**
+   * Media source service.
+   *
+   * @var \Drupal\islandora\MediaSource\MediaSourceService
+   */
   protected $mediaSource;
 
   /**

--- a/src/Plugin/ContextReaction/MappingUriPredicateReaction.php
+++ b/src/Plugin/ContextReaction/MappingUriPredicateReaction.php
@@ -9,6 +9,7 @@ use Drupal\islandora\ContextReaction\NormalizerAlterReaction;
 use Drupal\islandora\MediaSource\MediaSourceService;
 use Drupal\jsonld\Normalizer\NormalizerBase;
 use Drupal\media\MediaInterface;
+use Drupal\islandora\IslandoraUtils;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -32,13 +33,15 @@ class MappingUriPredicateReaction extends NormalizerAlterReaction {
                               $plugin_id,
                               $plugin_definition,
                               ConfigFactoryInterface $config_factory,
+                              IslandoraUtils $utils,
                               MediaSourceService $media_source) {
 
     parent::__construct(
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $config_factory
+      $config_factory,
+      $utils
     );
     $this->mediaSource = $media_source;
   }
@@ -52,6 +55,7 @@ class MappingUriPredicateReaction extends NormalizerAlterReaction {
       $plugin_id,
       $plugin_definition,
       $container->get('config.factory'),
+      $container->get('islandora.utils'),
       $container->get('islandora.media_source_service')
     );
   }
@@ -80,7 +84,7 @@ class MappingUriPredicateReaction extends NormalizerAlterReaction {
             // Swap media and file urls.
             if ($entity instanceof MediaInterface) {
               $file = $this->mediaSource->getSourceFile($entity);
-              $graph['@id'] = $file->url('canonical', ['absolute' => TRUE]);
+              $graph['@id'] = $this->utils->getDownloadUrl($file);
             }
             if (isset($graph[$drupal_predicate])) {
               if (!is_array($graph[$drupal_predicate])) {

--- a/src/PresetReaction/PresetReaction.php
+++ b/src/PresetReaction/PresetReaction.php
@@ -14,6 +14,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class PresetReaction extends ContextReactionPluginBase implements ContainerFactoryPluginInterface {
 
+  /**
+   * Action storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
   protected $actionStorage;
 
   /**

--- a/tests/src/Functional/GenerateDerivativeTestBase.php
+++ b/tests/src/Functional/GenerateDerivativeTestBase.php
@@ -7,6 +7,9 @@ namespace Drupal\Tests\islandora\Functional;
  */
 abstract class GenerateDerivativeTestBase extends IslandoraFunctionalTestBase {
 
+  /**
+   * {@inheritdoc}
+   */
   protected static $modules = ['context_ui'];
 
   /**

--- a/tests/src/Functional/IslandoraFunctionalTestBase.php
+++ b/tests/src/Functional/IslandoraFunctionalTestBase.php
@@ -20,8 +20,14 @@ class IslandoraFunctionalTestBase extends BrowserTestBase {
   use TestFileCreationTrait;
   use MediaTypeCreationTrait;
 
+  /**
+   * {@inheritdoc}
+   */
   protected static $modules = ['context_ui', 'field_ui', 'islandora'];
 
+  /**
+   * {@inheritdoc}
+   */
   protected static $configSchemaCheckerExclusions = [
     'jwt.config',
     'context.context.test',
@@ -31,10 +37,25 @@ class IslandoraFunctionalTestBase extends BrowserTestBase {
     'key.key.test',
   ];
 
+  /**
+   * Test node type.
+   *
+   * @var \Drupal\node\Entity\NodeType
+   */
   protected $testType;
 
+  /**
+   * Test media type.
+   *
+   * @var \Drupal\media\Entity\MediaType
+   */
   protected $testMediaType;
 
+  /**
+   * Test vocabulary.
+   *
+   * @var \Drupal\taxonomy\Entity\Vocabulary
+   */
   protected $testVocabulary;
 
   /**

--- a/tests/src/Functional/IslandoraFunctionalTestBase.php
+++ b/tests/src/Functional/IslandoraFunctionalTestBase.php
@@ -170,6 +170,10 @@ EOD;
       $destination->write($name, $source->read($name));
     }
 
+    $media_settings = $this->container->get('config.factory')->getEditable('media.settings');
+    $media_settings->set('standalone_url', TRUE);
+    $media_settings->save(TRUE);
+
     // Cache clear / rebuild.
     drupal_flush_all_caches();
     $this->container->get('router.builder')->rebuild();

--- a/tests/src/Functional/IslandoraFunctionalTestBase.php
+++ b/tests/src/Functional/IslandoraFunctionalTestBase.php
@@ -35,6 +35,7 @@ class IslandoraFunctionalTestBase extends BrowserTestBase {
     'context.context.media',
     'context.context.file',
     'key.key.test',
+    'media.settings',
   ];
 
   /**

--- a/tests/src/Kernel/EventGeneratorTest.php
+++ b/tests/src/Kernel/EventGeneratorTest.php
@@ -65,7 +65,7 @@ class EventGeneratorTest extends IslandoraKernelTestBase {
 
     // Create the event generator so we can test it.
     $this->eventGenerator = new EventGenerator(
-      $this->container->get('language_manager'),
+      $this->container->get('islandora.utils'),
       $this->container->get('islandora.media_source_service')
     );
   }

--- a/tests/src/Kernel/GeminiClientFactoryTest.php
+++ b/tests/src/Kernel/GeminiClientFactoryTest.php
@@ -18,6 +18,11 @@ use Psr\Log\LoggerInterface;
  */
 class GeminiClientFactoryTest extends IslandoraKernelTestBase {
 
+  /**
+   * Logger.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
   private $logger;
 
   /**

--- a/tests/src/Kernel/GeminiLookupTest.php
+++ b/tests/src/Kernel/GeminiLookupTest.php
@@ -23,18 +23,53 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 class GeminiLookupTest extends IslandoraKernelTestBase {
 
+  /**
+   * JWT Auth.
+   *
+   * @var \Drupal\jwt\Authentication\Provider\JwtAuth
+   */
   private $jwtAuth;
 
+  /**
+   * Logger.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
   private $logger;
 
+  /**
+   * Guzzle.
+   *
+   * @var \GuzzleHttp\Client
+   */
   private $guzzle;
 
+  /**
+   * Gemini client.
+   *
+   * @var \Islandora\Crayfish\Commons\Client\GeminiClient
+   */
   private $geminiClient;
 
+  /**
+   * Media source service.
+   *
+   * @var \Drupal\islandora\MediaSource\MediaSourceService
+   */
   private $mediaSource;
 
+  /**
+   * An entity.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface
+   */
   private $entity;
 
+  /**
+   * A media.
+   *
+   * @var \Drupal\media\MediaInterface
+   */
   private $media;
 
   /**


### PR DESCRIPTION
**GitHub Issues**
Part of 
- https://github.com/Islandora-CLAW/CLAW/issues/1110
- https://github.com/Islandora-CLAW/CLAW/issues/1095
- https://github.com/Islandora-CLAW/CLAW/issues/1144

# What does this Pull Request do?

Refactors the code so every time we request a URL from an entity, it goes through a utility function for consistency.  This makes us Drupal 8.7 compatible, as well as solves our outstanding issue with url aliases for nodes.

# What's new?
Three new utility functions for generating URLs in `IslandoraUtils`.  Then everything else is just the dependency injection boilerplate to get `IslandoraUtils` into all the other classes.

Also had to touch up tests so that they set the checkbox for keeping media urls as in 8.6.

# How should this be tested?

claw-playbook PR pending

# Interested parties
@Islandora-CLAW/committers
