### PR TITLE
Adds a Context Condition to detect the MIME type of the media

### DIFF
--- a/config/schema/islandora.schema.yml
+++ b/config/schema/islandora.schema.yml
@@ -113,6 +113,13 @@ condition.plugin.media_uses_filesystem:
       sequence:
         type: string
 
+condition.plugin.media_has_mimetype:
+  type: condition.plugin
+  mapping:
+    mimetypes:
+      type: text
+      label: 'Mime types'
+
 condition.plugin.content_entity_type:
   type: condition.plugin
   mapping:

--- a/islandora.module
+++ b/islandora.module
@@ -347,6 +347,7 @@ function islandora_form_block_form_alter(&$form, FormStateInterface $form_state,
   unset($form['visibility']['file_uses_filesystem']);
   unset($form['visibility']['node_has_term']);
   unset($form['visibility']['media_uses_filesystem']);
+  unset($form['visibility']['media_has_mimetype']);
 }
 
 /**

--- a/src/Plugin/Condition/MediaHasMimetype.php
+++ b/src/Plugin/Condition/MediaHasMimetype.php
@@ -161,4 +161,14 @@ class MediaHasMimetype extends ConditionPluginBase implements ContainerFactoryPl
     }
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return array_merge(
+      ['mimetypes' => ''],
+      parent::defaultConfiguration()
+    );
+  }
+
 }

--- a/src/Plugin/Condition/MediaHasMimetype.php
+++ b/src/Plugin/Condition/MediaHasMimetype.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Drupal\islandora\Plugin\Condition;
+
+use Drupal\Core\Condition\ConditionPluginBase;
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\islandora\IslandoraUtils;
+use Drupal\islandora\MediaSource\MediaSourceService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a condition based on a node's media's MimeType.
+ *
+ * Note that this condition applies when the parent node is viewed.
+ * It is not fired during ingest (i.e., it doesn't apply to
+ * derivative generation).
+ *
+ * @Condition(
+ *   id = "media_has_mimetype",
+ *   label = @Translation("Media has Mime type"),
+ *   context_definitions = {
+ *     "node" = @ContextDefinition("entity:node", label = @Translation("node"))
+ *   }
+ * )
+ */
+class MediaHasMimetype extends ConditionPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * Islandora utils.
+   *
+   * @var \Drupal\islandora\IslandoraUtils
+   */
+  protected $utils;
+
+  /**
+   * Term storage.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   */
+  protected $entityTypeManager;
+
+  /**
+   * A MediaSourceService.
+   *
+   * @var \Drupal\islandora\MediaSource\MediaSourceService
+   */
+  private $mediaSource;
+
+  /**
+   * Constructor.
+   *
+   * @param array $configuration
+   *   The plugin configuration, i.e. an array with configuration values keyed
+   *   by configuration option name. The special key 'context' may be used to
+   *   initialize the defined contexts by setting it to an array of context
+   *   values keyed by context names.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\islandora\IslandoraUtils $utils
+   *   Islandora utility functions.
+   * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
+   *   Entity type manager.
+   * @param \Drupal\islandora\MediaSource\MediaSourceService $media_source
+   *   Media source service.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    IslandoraUtils $utils,
+    EntityTypeManager $entity_type_manager,
+    MediaSourceService $media_source
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $utils);
+    $this->utils = $utils;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->mediaSource = $media_source;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('islandora.utils'),
+      $container->get('entity_type.manager'),
+      $container->get('islandora.media_source_service')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $form['mimetypes'] = [
+      '#type' => 'textfield',
+      '#title' => t('Mime types'),
+      '#default_value' => $this->configuration['mimetypes'],
+      '#required' => TRUE,
+      '#maxlength' => 256,
+      '#description' => t('Comma-delimited list of Mime types (e.g. image/jpeg, video/mp4, etc...) that trigger the condition.'),
+    ];
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    $this->configuration['mimetypes'] = $form_state->getValue('mimetypes');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function summary() {
+    $mimetypes = $this->configuration['mimetypes'];
+    return $this->t(
+      'The media has one of the Mime types @mimetypes',
+      [
+        '@mimetypes' => $mimetypes,
+      ]
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function evaluate() {
+    if (empty($this->configuration['mimetypes']) && !$this->isNegated()) {
+      return TRUE;
+    }
+
+    $node = \Drupal::routeMatch()->getParameter('node');
+
+    if (is_null($node) || is_string($node)) {
+      return FALSE;
+    }
+
+    $media = $this->utils->getMedia($node);
+
+    if (count($media) > 0) {
+      $mimetypes = explode(',', str_replace(' ', '', $this->configuration['mimetypes']));
+      foreach ($media as $medium) {
+        $file = $this->mediaSource->getSourceFile($medium);
+        if (in_array($file->getMimeType(), $mimetypes)) {
+          return $this->isNegated() ? FALSE : TRUE;
+        }
+      }
+    }
+    else {
+      return FALSE;
+    }
+  }
+
+}


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1138

# What does this Pull Request do?

Adds a Context Condition to detect the MIME type of the media being displayed with a node or as a media.

# What's new?

A new Condition class file. The Condition is also in the list of Conditions to hide from the Block placement GUI.

# How should this be tested?

The boring way:

1. Check out this branch and `drush cr`.
1. Create a new Context using the "Media Has Mime type" condition.
1. Configure the condition to use the 'image/png' Mime type.
1. Use "Theme" as the Reaction, and choose the Bartik theme.
1. Go to an image object whose Original File has the specified Mime type.
1. The theme should have changed to Bartik.
1. Go to an image object whose Original File is not a PNG. The theme should be the default.
1. Add another Mime type to the condition's configuration, but put it before 'image/png' and separate the Mime types with a comma.
1. Go back to the PNG Originalfile node and the other. The behavior should be the same as the first test.

A much cooler way of testing:

1. Check out this branch and `drush cr`.
1. Create a new PDF object, but do not check anything in the "Display hints" field.
1. Create a new Context using the "Media Has Mime type" condition.
1. Configure the Condition to use the 'application/pdf' Mime type.
1. As a Reaction, choose "Change View Mode", then in the "View Mode" list, choose Media/PDFjs.
1. Save the Reaction.
1. Visit the new PDF object. It should display using PDFjs. No need to indicate PDFjs on the node edit form!


# Interested parties
@Islandora-CLAW/committers
