### PR TITLE
Adds a Context Condition that tests a node's parent

### DIFF
--- a/config/schema/islandora.schema.yml
+++ b/config/schema/islandora.schema.yml
@@ -87,10 +87,10 @@ condition.plugin.node_has_parent:
   type: condition.plugin
   mapping:
     parent_nid:
-      type: ignore
+      type: integer
       label: 'Parent node'
     parent_reference_field:
-      type: ignore
+      type: string
       label: 'Parent reference field'
 
 condition.plugin.media_has_term:

--- a/config/schema/islandora.schema.yml
+++ b/config/schema/islandora.schema.yml
@@ -83,6 +83,16 @@ condition.plugin.node_has_term:
       type: text
       label: 'Taxonomy Term URI'
 
+condition.plugin.node_has_parent:
+  type: condition.plugin
+  mapping:
+    parent_nid:
+      type: ignore
+      label: 'Parent node'
+    parent_reference_field:
+      type: ignore
+      label: 'Parent reference field'
+
 condition.plugin.media_has_term:
   type: condition.plugin
   mapping:

--- a/islandora.module
+++ b/islandora.module
@@ -346,6 +346,7 @@ function islandora_form_block_form_alter(&$form, FormStateInterface $form_state,
   unset($form['visibility']['media_has_term']);
   unset($form['visibility']['file_uses_filesystem']);
   unset($form['visibility']['node_has_term']);
+  unset($form['visibility']['node_has_parent']);
   unset($form['visibility']['media_uses_filesystem']);
 }
 

--- a/src/Plugin/Condition/NodeHasParent.php
+++ b/src/Plugin/Condition/NodeHasParent.php
@@ -96,7 +96,7 @@ class NodeHasParent extends ConditionPluginBase implements ContainerFactoryPlugi
       '#options' => $options,
       '#default_value' => $this->configuration['parent_reference_field'],
       '#required' => TRUE,
-      '#description' => t("Machine field name that contains references to parent node. You normally do not need to change this value."),
+      '#description' => t("Machine field name that contains references to parent node."),
     ];
 
     return parent::buildConfigurationForm($form, $form_state);

--- a/src/Plugin/Condition/NodeHasParent.php
+++ b/src/Plugin/Condition/NodeHasParent.php
@@ -89,7 +89,8 @@ class NodeHasParent extends ConditionPluginBase implements ContainerFactoryPlugi
       '#target_type' => 'node',
     ];
     $field_map = \Drupal::service('entity_field.manager')->getFieldMapByFieldType('entity_reference');
-    $options = array_keys($field_map['node']);
+    $node_fields = array_keys($field_map['node']);
+    $options = array_combine($node_fields, $node_fields);
     $form['parent_reference_field'] = [
       '#type' => 'select',
       '#title' => t('Field that contains reference to parents'),

--- a/src/Plugin/Condition/NodeHasParent.php
+++ b/src/Plugin/Condition/NodeHasParent.php
@@ -88,9 +88,12 @@ class NodeHasParent extends ConditionPluginBase implements ContainerFactoryPlugi
       '#description' => t("Can be a collection node or a compound object."),
       '#target_type' => 'node',
     ];
+    $field_map = \Drupal::service('entity_field.manager')->getFieldMapByFieldType('entity_reference');
+    $options = array_keys($field_map['node']);
     $form['parent_reference_field'] = [
-      '#type' => 'textfield',
+      '#type' => 'select',
       '#title' => t('Field name that contains reference to parents'),
+      '#options' => $options,
       '#default_value' => $this->configuration['parent_reference_field'],
       '#required' => TRUE,
       '#description' => t("Machine field name that contains references to parent node. You normally do not need to change this value."),

--- a/src/Plugin/Condition/NodeHasParent.php
+++ b/src/Plugin/Condition/NodeHasParent.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Drupal\islandora\Plugin\Condition;
+
+use Drupal\Core\Condition\ConditionPluginBase;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a condition to detect node's parent.
+ *
+ * @Condition(
+ *   id = "node_has_parent",
+ *   label = @Translation("Node has parent"),
+ *   context = {
+ *     "node" = @ContextDefinition("entity:node", required = TRUE , label = @Translation("node"))
+ *   }
+ * )
+ */
+class NodeHasParent extends ConditionPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * Node storage.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructor.
+   *
+   * @param array $configuration
+   *   The plugin configuration, i.e. an array with configuration values keyed
+   *   by configuration option name. The special key 'context' may be used to
+   *   initialize the defined contexts by setting it to an array of context
+   *   values keyed by context names.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
+   *   Entity type manager.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManager $entity_type_manager
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return parent::defaultConfiguration() + [
+      'parent_reference_field' => 'field_member_of',
+      'parent_nid' => '',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $form['parent_nid'] = [
+      '#type' => 'entity_autocomplete',
+      '#title' => t('Parent node'),
+      '#default_value' => $this->entityTypeManager->getStorage('node')->load($this->configuration['parent_nid']),
+      '#required' => TRUE,
+      '#description' => t("Can be a collection node or a compound object."),
+      '#target_type' => 'node',
+    ];
+    $form['parent_reference_field'] = [
+      '#type' => 'textfield',
+      '#title' => t('Field name that contains reference to parents'),
+      '#default_value' => $this->configuration['parent_reference_field'],
+      '#required' => TRUE,
+      '#description' => t("Machine field name that contains references to parent node. You normally do not need to change this value."),
+    ];
+
+    return parent::buildConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    $this->configuration['parent_nid'] = $form_state->getValue('parent_nid');
+    $this->configuration['parent_reference_field'] = $form_state->getValue('parent_reference_field');
+    parent::submitConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function evaluate() {
+    if (empty($this->configuration['parent_nid']) && !$this->isNegated()) {
+      return TRUE;
+    }
+
+    $node = $this->getContextValue('node');
+    if (!$node) {
+      return FALSE;
+    }
+    return $this->evaluateEntity($node);
+  }
+
+  /**
+   * Evaluates if an entity has the specified node as its parent.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity to evalute.
+   *
+   * @return bool
+   *   TRUE if entity references the specified parent.
+   */
+  protected function evaluateEntity(EntityInterface $entity) {
+    foreach ($entity->referencedEntities() as $referenced_entity) {
+      if ($entity->getEntityTypeID() == 'node' && $referenced_entity->getEntityTypeId() == 'node') {
+        $parent_reference_field = $this->configuration['parent_reference_field'];
+        $field = $entity->get($parent_reference_field);
+        if (!$field->isEmpty()) {
+          $nids = $field->getValue();
+          foreach ($nids as $nid) {
+            if ($nid['target_id'] == $this->configuration['parent_nid']) {
+              return $this->isNegated() ? FALSE : TRUE;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function summary() {
+    if (!empty($this->configuration['negate'])) {
+      return $this->t('The node does not have node @nid as its parent.', ['@nid' => $this->configuration['parent_nid']]);
+    }
+    else {
+      return $this->t('The node has node @nid as its parent.', ['@nid' => $this->configuration['parent_nid']]);
+    }
+  }
+
+}

--- a/src/Plugin/Condition/NodeHasParent.php
+++ b/src/Plugin/Condition/NodeHasParent.php
@@ -92,11 +92,11 @@ class NodeHasParent extends ConditionPluginBase implements ContainerFactoryPlugi
     $options = array_keys($field_map['node']);
     $form['parent_reference_field'] = [
       '#type' => 'select',
-      '#title' => t('Field name that contains reference to parents'),
+      '#title' => t('Field that contains reference to parents'),
       '#options' => $options,
       '#default_value' => $this->configuration['parent_reference_field'],
       '#required' => TRUE,
-      '#description' => t("Machine field name that contains references to parent node."),
+      '#description' => t("Machine name of field that contains references to parent node."),
     ];
 
     return parent::buildConfigurationForm($form, $form_state);


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1170

# What does this Pull Request do?

Adds a Context Condition that tests a node's parent, which can be either a collection object or not.

# What's new?

Adds the new Condition, and also adds its ID to the list in `islandora.module` that excludes this condition from the Block placement UI.

# How should this be tested?

1. Check out this branch and `drush cr`.
1. Create a new Context using the "Node has parent" condition.
1. In the Parent Node field, enter the name of a collection.
1. Choose the name of the field that contains the parent reference (probably `field_member_of`)
1. Use "Theme" as the Reaction, and choose the Bartik theme.
1. Go to an object that is not in the collection you named in your Conext. The theme should remain the default.
1. Now go to an object that is in the collection you named in your Conext. The theme should change to Bartik.
1. Go back to the object not in the collection.
1. To test membership of a complex object, add an object to another non-collection object as a child.
1. Reconfigure your context's condition to indicate the non-collection object as the parent.
1. Visit the child object. The theme should change to Bartik.


# Interested parties
@Islandora-CLAW/committers
