### PR TITLE
NodeHadNamespace condition uses hard-coded field, should use configured field

### DIFF
--- a/src/Plugin/Condition/NodeHadNamespace.php
+++ b/src/Plugin/Condition/NodeHadNamespace.php
@@ -145,8 +145,8 @@ class NodeHadNamespace extends ConditionPluginBase implements ContainerFactoryPl
    *   TRUE if entity has the specified namespace, otherwise FALSE.
    */
   protected function evaluateEntity(EntityInterface $entity) {
-    if ($entity->hasField('field_pid')) {
-      $pid_field = $this->configuration['pid_field'];
+    $pid_field = $this->configuration['pid_field'];
+    if ($entity->hasField($pid_field)) {
       $pid_value = $entity->get($pid_field)->getValue();
       $pid = $pid_value[0]['value'];
       $namespace = strtok($pid, ':') . ':';


### PR DESCRIPTION
**GitHub Issue**: (https://github.com/Islandora-CLAW/CLAW/issues/1199)


# What does this Pull Request do?

Replaces reference to `field_pid` with the configured field name.

# What's new?

* Does this change require documentation to be updated? No
* Does this change add any new dependencies?  No
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? Yes, but to the expected behavior.

# How should this be tested?

1. Populate the Rights field of an object with 'islandora:100'
1. Check out this branch and `drush cr`.
1. Create a new Context using the "Node had 7.x namespace" condition.
1. In the Islandora 7.x Namespaces field, enter 'islandora:`
1. Choose `field_rights` in the list of available fields.
1. Use "Theme" as the Reaction, and choose the Bartik theme.
1. Go to the object you edited in the first step. You should see the Bartik theme.
1. Visit some other node. The theme should now be the default theme.

# Additional Notes:

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-CLAW/committers
