### PR TITLE
Add in-form help text for Media Use field on the four standard media types

### DIFF
--- a/modules/islandora_core_feature/config/install/field.field.media.audio.field_media_use.yml
+++ b/modules/islandora_core_feature/config/install/field.field.media.audio.field_media_use.yml
@@ -10,7 +10,7 @@ field_name: field_media_use
 entity_type: media
 bundle: audio
 label: 'Media Use'
-description: ''
+description: 'Defined by Portland Common Data Model: Use Extension https://pcdm.org/2015/05/12/use. ''Original File'' will trigger creation of derivatives.'
 required: false
 translatable: false
 default_value: {  }

--- a/modules/islandora_core_feature/config/install/field.field.media.file.field_media_use.yml
+++ b/modules/islandora_core_feature/config/install/field.field.media.file.field_media_use.yml
@@ -10,7 +10,7 @@ field_name: field_media_use
 entity_type: media
 bundle: file
 label: 'Media Use'
-description: ''
+description: 'Defined by Portland Common Data Model: Use Extension https://pcdm.org/2015/05/12/use. ''Original File'' will trigger creation of derivatives.'
 required: false
 translatable: true
 default_value: {  }

--- a/modules/islandora_core_feature/config/install/field.field.media.image.field_media_use.yml
+++ b/modules/islandora_core_feature/config/install/field.field.media.image.field_media_use.yml
@@ -10,7 +10,7 @@ field_name: field_media_use
 entity_type: media
 bundle: image
 label: 'Media Use'
-description: ''
+description: 'Defined by Portland Common Data Model: Use Extension https://pcdm.org/2015/05/12/use. ''Original File'' will trigger creation of derivatives.'
 required: false
 translatable: true
 default_value: {  }

--- a/modules/islandora_core_feature/config/install/field.field.media.video.field_media_use.yml
+++ b/modules/islandora_core_feature/config/install/field.field.media.video.field_media_use.yml
@@ -10,7 +10,7 @@ field_name: field_media_use
 entity_type: media
 bundle: video
 label: 'Media Use'
-description: ''
+description: 'Defined by Portland Common Data Model: Use Extension https://pcdm.org/2015/05/12/use. ''Original File'' will trigger creation of derivatives.'
 required: false
 translatable: true
 default_value: {  }


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1186

* Other Relevant Links: old PR made to the wrong repo: https://github.com/Islandora-CLAW/islandora_defaults/pull/3

# What does this Pull Request do?

Adds a bit of help text to the Media Use field to explain which selection generates derivatives, and how to find out more.

`Defined by Portland Common Data Model: Use Extension https://pcdm.org/2015/05/12/use. 'Original File' will trigger creation of derivatives.`

# How should this be tested?

Pull in the changes and do a feature import (`drush fim -y islandora_core_feature`), then go try to add new Media in each of the existing types, verifying that the help text appears.

# Interested parties
@seth-shaw-unlv @mjordan 