### PR TITLE
Node Is Published Condition

### DIFF
--- a/src/Plugin/Condition/NodeIsPublished.php
+++ b/src/Plugin/Condition/NodeIsPublished.php
@@ -3,9 +3,7 @@
 namespace Drupal\islandora\Plugin\Condition;
 
 use Drupal\Core\Condition\ConditionPluginBase;
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManager;
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -92,8 +90,8 @@ class NodeIsPublished extends ConditionPluginBase implements ContainerFactoryPlu
 
     return FALSE;
   }
-  
-    /**
+
+  /**
    * {@inheritdoc}
    */
   public function summary() {

--- a/src/Plugin/Condition/NodeIsPublished.php
+++ b/src/Plugin/Condition/NodeIsPublished.php
@@ -1,3 +1,12 @@
+<?php
+
+namespace Drupal\islandora\Plugin\Condition;
+
+use Drupal\Core\Condition\ConditionPluginBase;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**

--- a/src/Plugin/Condition/NodeIsPublished.php
+++ b/src/Plugin/Condition/NodeIsPublished.php
@@ -21,13 +21,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class NodeIsPublished extends ConditionPluginBase implements ContainerFactoryPluginInterface {
 
   /**
-   * Islandora utils.
-   *
-   * @var \Drupal\islandora\IslandoraUtils
-   */
-  protected $utils;
-
-  /**
    * Term storage.
    *
    * @var \Drupal\Core\Entity\EntityTypeManager
@@ -46,8 +39,6 @@ class NodeIsPublished extends ConditionPluginBase implements ContainerFactoryPlu
    *   The plugin_id for the plugin instance.
    * @param mixed $plugin_definition
    *   The plugin implementation definition.
-   * @param \Drupal\islandora\IslandoraUtils $utils
-   *   Islandora utils.
    * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
    *   Entity type manager.
    */
@@ -55,11 +46,9 @@ class NodeIsPublished extends ConditionPluginBase implements ContainerFactoryPlu
     array $configuration,
     $plugin_id,
     $plugin_definition,
-    IslandoraUtils $utils,
     EntityTypeManager $entity_type_manager
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->utils = $utils;
     $this->entityTypeManager = $entity_type_manager;
   }
 
@@ -71,7 +60,6 @@ class NodeIsPublished extends ConditionPluginBase implements ContainerFactoryPlu
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('islandora.utils'),
       $container->get('entity_type.manager')
     );
   }

--- a/src/Plugin/Condition/NodeIsPublished.php
+++ b/src/Plugin/Condition/NodeIsPublished.php
@@ -1,0 +1,99 @@
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides an 'Is Published' condition for nodes.
+ *
+ * @Condition(
+ *   id = "node_is_published",
+ *   label = @Translation("Node is published"),
+ *   context = {
+ *     "node" = @ContextDefinition("entity:node", required = TRUE , label = @Translation("node"))
+ *   }
+ * )
+ */
+class NodeIsPublished extends ConditionPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * Islandora utils.
+   *
+   * @var \Drupal\islandora\IslandoraUtils
+   */
+  protected $utils;
+
+  /**
+   * Term storage.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructor.
+   *
+   * @param array $configuration
+   *   The plugin configuration, i.e. an array with configuration values keyed
+   *   by configuration option name. The special key 'context' may be used to
+   *   initialize the defined contexts by setting it to an array of context
+   *   values keyed by context names.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\islandora\IslandoraUtils $utils
+   *   Islandora utils.
+   * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager
+   *   Entity type manager.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    IslandoraUtils $utils,
+    EntityTypeManager $entity_type_manager
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->utils = $utils;
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('islandora.utils'),
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function evaluate() {
+    $node = $this->getContextValue('node');
+    if (!$node  && !$this->isNegated()) {
+      return FALSE;
+    }
+    if ($node->isPublished() && !$this->isNegated()) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+  
+    /**
+   * {@inheritdoc}
+   */
+  public function summary() {
+    if (!empty($this->configuration['negate'])) {
+      return $this->t('The node is not published.');
+    }
+    else {
+      return $this->t('The node is published.');
+    }
+  }
+
+}


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1214

# What does this Pull Request do?

Adds a new Condition plugin to check if a Node is published or not.

# What's new?
* Added a "Node Is Published" condition plugin.
* Does this change require documentation to be updated? No.
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? Not unless you want it to.

# How should this be tested?

1. Apply the PR
1. Clear cache
1. Add the 'Node is Published' condition to repository content condition (http://localhost:8000/admin/structure/context/repository_content) and check 'Require all conditions' checkbox: 
![Screen Shot 2019-07-10 at 1 21 52 PM](https://user-images.githubusercontent.com/29869988/61002162-d3872180-a315-11e9-9486-977749070700.png)
1. Create a new islandora_object node BUT don't select 'Published'. The node's page will show an 'Unpublished' flag and you won't see the Fedora URI pseudo-field. It won't be in Gemini, the triple-store, or Fedora either. 
1. Edit the node to make it published and save it. You will now see the Fedora URI pseudo-field displayed and can view the object in Gemini, the triplestore, and Fedora.

# Additional Notes:

I'm not making this part of the repository context default settings, simply making the capability available. 

Also, if you unpublish a Node it will stop sending updates to Fedora and the triplestore. Test this by unpublishing a node then making changes to the metadata and saving them. Fedora will not get the updates. Once you re-publish the node the updates will be persisted to Fedora.

# Interested parties
@Islandora-CLAW/committers
