### PR TITLE
Issue #1211 Update field.storage.node.field_display_hints.yml

### DIFF
--- a/modules/islandora_core_feature/config/install/field.storage.node.field_display_hints.yml
+++ b/modules/islandora_core_feature/config/install/field.storage.node.field_display_hints.yml
@@ -12,7 +12,7 @@ settings:
   target_type: taxonomy_term
 module: core
 locked: false
-cardinality: -1
+cardinality: 1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1211

# What does this Pull Request do?

Makes Display Hints a single-option field so users can't turn on two different displays at once for a single object (because it doesn't work when they do).

# What's new?
Literally just a -1 becoming a 1 in the right place. But this does also add "N/A" as a default option, which I think Drupal requires for fields with limits? I didn't add it. It just showed up when the cardinality was changed. 

* Does this change require documentation to be updated? Some screenshots may need updating. 
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? I don't think so? The addition of N/A is the part that seems most disruptive.

# How should this be tested?

Go to create a Repository Object. Check off multiple Display Hints and save. It's allowed, but doesn't translate to multiple displays being implemented:

![image](https://user-images.githubusercontent.com/2371345/61142899-3c51d380-a4a7-11e9-9842-ff3aa22f5044.png)


Pull down the change, run `drush fim -y islandora_core_feature` in the drupal directory, then create another Repository Object. This time it's a radio button that only allows one selection. N/A is also and option and defaults to Drupal display style, like this:

![image](https://user-images.githubusercontent.com/2371345/61142880-30fea800-a4a7-11e9-879d-3ec881f51e1d.png)

# Additional Notes:
This isn't my wheelhouse but I'm trying to learn, so extra scrutiny is appreciated.

# Interested parties
@Islandora-CLAW/committers
