### PR TITLE
Fix Breadcrumb error when viewing node tab: Issue 1238

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: php
 php:
   - 7.1
   - 7.2
+services:
+  - mysql
 
 matrix:
     fast_finish: true

--- a/modules/islandora_breadcrumbs/islandora_breadcrumbs.services.yml
+++ b/modules/islandora_breadcrumbs/islandora_breadcrumbs.services.yml
@@ -1,6 +1,6 @@
 services:
   islandora_breadcrumbs.breadcrumb:
     class: Drupal\islandora_breadcrumbs\IslandoraBreadcrumbBuilder
-    arguments: ['@config.factory']
+    arguments: ['@entity_type.manager', '@config.factory']
     tags:
       - { name: breadcrumb_builder, priority: 100 }

--- a/modules/islandora_breadcrumbs/src/IslandoraBreadcrumbBuilder.php
+++ b/modules/islandora_breadcrumbs/src/IslandoraBreadcrumbBuilder.php
@@ -38,7 +38,6 @@ class IslandoraBreadcrumbBuilder implements BreadcrumbBuilderInterface {
     // because getParameters sometimes returns a node and sometimes
     // returns a node object.
     $nid = $attributes->getRawParameters()->get('node');
-    \Drupal::logger('test')->notice('Route Node ID: ' . print_r($nid, TRUE));
     if (!empty($nid)) {
       $node = \Drupal::entityTypeManager()->getStorage('node')->load($nid);
       return (!empty($node) && $node->hasField($this->config->get('referenceField')) && !$node->get($this->config->get('referenceField'))->isEmpty());

--- a/modules/islandora_breadcrumbs/src/IslandoraBreadcrumbBuilder.php
+++ b/modules/islandora_breadcrumbs/src/IslandoraBreadcrumbBuilder.php
@@ -34,9 +34,9 @@ class IslandoraBreadcrumbBuilder implements BreadcrumbBuilderInterface {
    * {@inheritdoc}
    */
   public function applies(RouteMatchInterface $attributes) {
-    // Using getRawParameters for consistency (always gives a string)
-    // because getParameters sometimes returns a node and sometimes
-    // returns a node object.
+    // Using getRawParameters for consistency (always gives a
+    // node ID string) because getParameters sometimes returns
+    // a node ID string and sometimes returns a node object.
     $nid = $attributes->getRawParameters()->get('node');
     if (!empty($nid)) {
       $node = \Drupal::entityTypeManager()->getStorage('node')->load($nid);

--- a/modules/islandora_breadcrumbs/src/IslandoraBreadcrumbBuilder.php
+++ b/modules/islandora_breadcrumbs/src/IslandoraBreadcrumbBuilder.php
@@ -49,7 +49,8 @@ class IslandoraBreadcrumbBuilder implements BreadcrumbBuilderInterface {
    */
   public function build(RouteMatchInterface $route_match) {
 
-    $node = $route_match->getParameter('node');
+    $nid = $route_match->getRawParameters()->get('node');
+    $node = \Drupal::entityTypeManager()->getStorage('node')->load($nid);
     $breadcrumb = new Breadcrumb();
 
     $chain = [];

--- a/modules/islandora_breadcrumbs/src/IslandoraBreadcrumbBuilder.php
+++ b/modules/islandora_breadcrumbs/src/IslandoraBreadcrumbBuilder.php
@@ -3,6 +3,7 @@
 namespace Drupal\islandora_breadcrumbs;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Breadcrumb\Breadcrumb;
 use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
@@ -21,12 +22,22 @@ class IslandoraBreadcrumbBuilder implements BreadcrumbBuilderInterface {
   protected $config;
 
   /**
+   * Storage to load nodes.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $nodeStorage;
+
+  /**
    * Constructs a breadcrumb builder.
    *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_manager
+   *   Storage to load nodes.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The configuration factory.
    */
-  public function __construct(ConfigFactoryInterface $config_factory) {
+  public function __construct(EntityTypeManagerInterface $entity_manager, ConfigFactoryInterface $config_factory) {
+    $this->nodeStorage = $entity_manager->getStorage('node');
     $this->config = $config_factory->get('islandora.breadcrumbs');
   }
 
@@ -39,7 +50,7 @@ class IslandoraBreadcrumbBuilder implements BreadcrumbBuilderInterface {
     // a node ID string and sometimes returns a node object.
     $nid = $attributes->getRawParameters()->get('node');
     if (!empty($nid)) {
-      $node = \Drupal::entityTypeManager()->getStorage('node')->load($nid);
+      $node = $this->nodeStorage->load($nid);
       return (!empty($node) && $node->hasField($this->config->get('referenceField')) && !$node->get($this->config->get('referenceField'))->isEmpty());
     }
   }
@@ -50,7 +61,7 @@ class IslandoraBreadcrumbBuilder implements BreadcrumbBuilderInterface {
   public function build(RouteMatchInterface $route_match) {
 
     $nid = $route_match->getRawParameters()->get('node');
-    $node = \Drupal::entityTypeManager()->getStorage('node')->load($nid);
+    $node = $this->nodeStorage->load($nid);
     $breadcrumb = new Breadcrumb();
 
     $chain = [];

--- a/modules/islandora_breadcrumbs/src/IslandoraBreadcrumbBuilder.php
+++ b/modules/islandora_breadcrumbs/src/IslandoraBreadcrumbBuilder.php
@@ -34,10 +34,14 @@ class IslandoraBreadcrumbBuilder implements BreadcrumbBuilderInterface {
    * {@inheritdoc}
    */
   public function applies(RouteMatchInterface $attributes) {
-    $parameters = $attributes->getParameters()->all();
-    if (!empty($parameters['node'])) {
-      return ($parameters['node']->hasField($this->config->get('referenceField')) &&
-              !$parameters['node']->get($this->config->get('referenceField'))->isEmpty());
+    // Using getRawParameters for consistency (always gives a string)
+    // because getParameters sometimes returns a node and sometimes
+    // returns a node object.
+    $nid = $attributes->getRawParameters()->get('node');
+    \Drupal::logger('test')->notice('Route Node ID: ' . print_r($nid, TRUE));
+    if (!empty($nid)) {
+      $node = \Drupal::entityTypeManager()->getStorage('node')->load($nid);
+      return (!empty($node) && $node->hasField($this->config->get('referenceField')) && !$node->get($this->config->get('referenceField'))->isEmpty());
     }
   }
 


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1238

# What does this Pull Request do?

Uses the getRawParameter instead of getParameter for loading the node in question. getParameter has inconsistent behavior, providing a node object when viewing the node page but only providing the node id as a string when viewing a tab, so we use getRawParameter which _always_ gives the node id as a string.

# What's new?

* Changes BreadcrumbBuilder::applies to use getRawParameter instead of getParameter.
* Does this change require documentation to be updated? No.
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? No.

# How should this be tested?

- Enable the islandora_breadcrumbs module.
- Visit a repository item page (loads fine).
- Click on the 'Media' tab (crashes).
- Apply the PR.
- Reload the crashed page (loades fine).
- All other pages should load fine as well.

# Interested parties
@elizoller and @Islandora-CLAW/committers
