### PR TITLE
Fixes PHP warning by testing pseudo_bundles before iterating.

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -362,14 +362,16 @@ function islandora_entity_extra_field_info() {
 
   $pseudo_bundles = $config_factory->get(IslandoraSettingsForm::GEMINI_PSEUDO);
 
-  foreach ($pseudo_bundles as $key) {
-    list($bundle, $content_entity) = explode(":", $key);
-    $extra_field[$content_entity][$bundle]['display']['field_gemini_uri'] = [
-      'label' => t('Fedora URI'),
-      'description' => t('The URI to the persistent'),
-      'weight' => 100,
-      'visible' => TRUE,
-    ];
+  if (!empty($pseudo_bundles)) {
+    foreach ($pseudo_bundles as $key) {
+      list($bundle, $content_entity) = explode(":", $key);
+      $extra_field[$content_entity][$bundle]['display']['field_gemini_uri'] = [
+        'label' => t('Fedora URI'),
+        'description' => t('The URI to the persistent'),
+        'weight' => 100,
+        'visible' => TRUE,
+      ];
+    }
   }
   return $extra_field;
 }


### PR DESCRIPTION
**GitHub Issue**:
https://github.com/Islandora-CLAW/CLAW/issues/1266

# What does this Pull Request do?

Fix PHP warning arising from no selection of bundles with Gemini URI pseudo field.
http://localhost:8000/admin/config/islandora/core

# How should this be tested?

We're seeing this warning on pre-1.0.0 instances. It doesn't appear to happen on a fresh VM since at least some bundles are selected. With no bundles selected warning does not occur, even with no patch.

# Interested parties
@Islandora-CLAW/committers
