### PR TITLE
Hide media and members tabs on non-Islandora objects.

### DIFF
--- a/src/Controller/ManageMediaController.php
+++ b/src/Controller/ManageMediaController.php
@@ -4,7 +4,6 @@ namespace Drupal\islandora\Controller;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Routing\RouteMatch;
-use Drupal\Core\Session\AccountInterface;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 
@@ -33,13 +32,22 @@ class ManageMediaController extends ManageMembersController {
     );
   }
 
+  /**
+   * Check if the object being displayed "is Islandora".
+   *
+   * @param \Drupal\Core\Routing\RouteMatch $route_match
+   *   The current routing match.
+   *
+   * @return \Drupal\Core\Access\AccessResultAllowed|\Drupal\Core\Access\AccessResultForbidden
+   *   Whether we can or can't show the "thing".
+   */
   public function access(RouteMatch $route_match) {
     if ($route_match->getParameters()->has('node')) {
       $node = $route_match->getParameter('node');
       if (! $node instanceof NodeInterface) {
         $node = Node::load($node);
       }
-      if ($node->hasField('field_model') || $node->hasField('field_member_of')) {
+      if ($node->hasField('field_model') && $node->hasField('field_member_of')) {
         return AccessResult::allowed();
       }
     }

--- a/src/Controller/ManageMediaController.php
+++ b/src/Controller/ManageMediaController.php
@@ -44,7 +44,7 @@ class ManageMediaController extends ManageMembersController {
   public function access(RouteMatch $route_match) {
     if ($route_match->getParameters()->has('node')) {
       $node = $route_match->getParameter('node');
-      if (! $node instanceof NodeInterface) {
+      if (!$node instanceof NodeInterface) {
         $node = Node::load($node);
       }
       if ($node->hasField('field_model') && $node->hasField('field_member_of')) {

--- a/src/Controller/ManageMediaController.php
+++ b/src/Controller/ManageMediaController.php
@@ -2,6 +2,10 @@
 
 namespace Drupal\islandora\Controller;
 
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Routing\RouteMatch;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 
 /**
@@ -14,6 +18,9 @@ class ManageMediaController extends ManageMembersController {
    *
    * @param \Drupal\node\NodeInterface $node
    *   Node you want to add a media to.
+   *
+   * @return array
+   *   Array of media types to add.
    */
   public function addToNodePage(NodeInterface $node) {
     return $this->generateTypeList(
@@ -24,6 +31,21 @@ class ManageMediaController extends ManageMembersController {
       $node,
       'field_media_of'
     );
+  }
+
+  public function access(AccountInterface $account, RouteMatch $route_match) {
+    if ($account->hasPermission('manage media')) {
+      if ($route_match->getParameters()->has('node')) {
+        $node = $route_match->getParameter('node');
+        if (! $node instanceof NodeInterface) {
+          $node = Node::load($node);
+        }
+        if ($node->hasField('field_content_model') || $node->hasField('field_member_of')) {
+          return AccessResult::allowed();
+        }
+      }
+    }
+    return AccessResult::forbidden();
   }
 
 }

--- a/src/Controller/ManageMediaController.php
+++ b/src/Controller/ManageMediaController.php
@@ -33,13 +33,13 @@ class ManageMediaController extends ManageMembersController {
     );
   }
 
-  public function access(AccountInterface $account, RouteMatch $route_match) {
+  public function access(RouteMatch $route_match) {
     if ($route_match->getParameters()->has('node')) {
       $node = $route_match->getParameter('node');
       if (! $node instanceof NodeInterface) {
         $node = Node::load($node);
       }
-      if ($node->hasField('field_content_model') || $node->hasField('field_member_of')) {
+      if ($node->hasField('field_model') || $node->hasField('field_member_of')) {
         return AccessResult::allowed();
       }
     }

--- a/src/Controller/ManageMediaController.php
+++ b/src/Controller/ManageMediaController.php
@@ -34,15 +34,13 @@ class ManageMediaController extends ManageMembersController {
   }
 
   public function access(AccountInterface $account, RouteMatch $route_match) {
-    if ($account->hasPermission('manage media')) {
-      if ($route_match->getParameters()->has('node')) {
-        $node = $route_match->getParameter('node');
-        if (! $node instanceof NodeInterface) {
-          $node = Node::load($node);
-        }
-        if ($node->hasField('field_content_model') || $node->hasField('field_member_of')) {
-          return AccessResult::allowed();
-        }
+    if ($route_match->getParameters()->has('node')) {
+      $node = $route_match->getParameter('node');
+      if (! $node instanceof NodeInterface) {
+        $node = Node::load($node);
+      }
+      if ($node->hasField('field_content_model') || $node->hasField('field_member_of')) {
+        return AccessResult::allowed();
       }
     }
     return AccessResult::forbidden();

--- a/src/EventSubscriber/AdminViewsRouteSubscriber.php
+++ b/src/EventSubscriber/AdminViewsRouteSubscriber.php
@@ -16,10 +16,12 @@ class AdminViewsRouteSubscriber extends RouteSubscriberBase {
   protected function alterRoutes(RouteCollection $collection) {
     if ($route = $collection->get('view.media_of.page_1')) {
       $route->setOption('_admin_route', 'TRUE');
+      $route->setRequirement('_permission', 'manage media');
       $route->setRequirement('_custom_access', '\Drupal\islandora\Controller\ManageMediaController::access');
     }
     if ($route = $collection->get('view.manage_members.page_1')) {
       $route->setOption('_admin_route', 'TRUE');
+      $route->setRequirement('_permission', 'manage members');
       $route->setRequirement('_custom_access', '\Drupal\islandora\Controller\ManageMediaController::access');
     }
   }

--- a/src/EventSubscriber/AdminViewsRouteSubscriber.php
+++ b/src/EventSubscriber/AdminViewsRouteSubscriber.php
@@ -16,6 +16,7 @@ class AdminViewsRouteSubscriber extends RouteSubscriberBase {
   protected function alterRoutes(RouteCollection $collection) {
     if ($route = $collection->get('view.media_of.page_1')) {
       $route->setOption('_admin_route', 'TRUE');
+      $route->setRequirement('_custom_access', '\Drupal\islandora\Controller\ManageMediaController::access');
     }
     if ($route = $collection->get('view.manage_members.page_1')) {
       $route->setOption('_admin_route', 'TRUE');

--- a/src/EventSubscriber/AdminViewsRouteSubscriber.php
+++ b/src/EventSubscriber/AdminViewsRouteSubscriber.php
@@ -20,6 +20,7 @@ class AdminViewsRouteSubscriber extends RouteSubscriberBase {
     }
     if ($route = $collection->get('view.manage_members.page_1')) {
       $route->setOption('_admin_route', 'TRUE');
+      $route->setRequirement('_custom_access', '\Drupal\islandora\Controller\ManageMediaController::access');
     }
   }
 


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1057

# What does this Pull Request do?

Alters the route for the views to add a permission requirement and a custom function to check for 2 expected fields indicating its an Islandora object.

# What's new?

* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?

1. Get an islandora 8 instance running.
1. Create a Repository Item (assuming you are using the islandora_defaults module)
1. See the Media and Members tab when viewing the node as the Administrator
1. Create a Basic Page
1. See the Media and Members tab when viewing the node as the Administrator

1. Pull in this PR on top of the existing module.
1. Rebuild routes and clear caches
    `drupal --root=/var/www/html/drupal router:rebuild && drupal --root=/var/www/html/drupal cache:rebuild`
1. View the Repository item, see the Media and Members tabs
1. View the Basic page, **don't** set the Media and Members tabs

# Interested parties
@Islandora-CLAW/committers
