### PR TITLE
adding tags for paged content

### DIFF
--- a/migrate/tags.csv
+++ b/migrate/tags.csv
@@ -12,3 +12,6 @@ islandora_models,"Collection","A collection is an aggregation of items",http://p
 islandora_models,"Image","A visual representation other than text, including all types of moving image and still image",http://purl.org/coar/resource_type/c_c513
 islandora_models,"Video","A recording of visual images, usually in motion and with sound accompaniment",http://purl.org/coar/resource_type/c_12ce
 islandora_models,"Digital Document","An electronic file or document.",https://schema.org/DigitalDocument
+islandora_models,"Paged Content","An Electronic Book, object with pages",https://schema.org/Book
+islandora_models,"Page","A page in an Electronic Paged Content Object",http://id.loc.gov/ontologies/bibframe/part
+islandora_models,"Publication Issue","A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.",https://schema.org/PublicationIssue


### PR DESCRIPTION
3 new tags to cover standard books and periodicals/newspapers 
and the sub Page model

**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1265

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

Adds islandora models for paged content

# What's new?
A in-depth description of the changes made by this PR. Technical details and
 possible side effects.

* Changes x feature to such that y
* Added x
* Removed y
* Does this change require documentation to be updated? 
* Does this change add any new dependencies? 
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? 
* Could this change impact execution of existing code?

# How should this be tested?

A description of what steps someone could take to:
import tags
ingest object as paged content
verify islandora actions process as needed

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-CLAW/committers
