### PR TITLE
IIIF Presentation API Validator

### DIFF
--- a/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
+++ b/modules/islandora_iiif/src/Plugin/views/style/IIIFManifest.php
@@ -176,7 +176,7 @@ class IIIFManifest extends StylePluginBase {
           // Create the IIIF URL for this file
           // Visiting $iiif_url will resolve to the info.json for the image.
           $file_url = $image->entity->url();
-
+          $mime_type = $image->entity->getMimeType();
           $iiif_url = rtrim($iiif_address, '/') . '/' . urlencode($file_url);
 
           // Create the necessary ID's for the canvas and annotation.
@@ -202,7 +202,6 @@ class IIIFManifest extends StylePluginBase {
             $properties = $image->getProperties();
             $width = isset($properties['width']) ? $properties['width'] : 0;
             $height = isset($properties['height']) ? $properties['height'] : 0;
-            $mime_type = $image->entity->getMimeType();
 
             // If this is a TIFF AND we don't know the width/height
             // see if we can get the image size via PHP's core function.


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1263

# What does this Pull Request do?

Adds additional properties to IIIF manifest required by Presentation API

# What's new?
Adds a label to the manifest, and adds width/height to the canvas and image. Also adds the mimetype of the image. Since Drupal treats TIFFs differently than normal images, the height/width is calculated special for TIFFs using PHP's [getimagesize](https://www.php.net/manual/en/function.getimagesize.php)

# How should this be tested?

- Enable islandora_iiif submodule
- Add your IIIF Server URL (the same one you'd have configured for OSD) at /admin/config/islandora/iiif
- Import this "test" // "demo" view: https://gist.github.com/dannylamb/c90686957d3d5599f49f2cab02f045d4
- Access a node that has an image referencing the node via field_media_of e.g. /node/1
- Add "iiif-manifest" to the URL e.g. /node/1/iiif-manifest
- You should see the JSON of every image for the respective node
- Submit that URL to the IIIF Presentation API Validator at https://iiif.io/api/presentation/validator/service/

# Interested parties
@Islandora-CLAW/committers
