### PR TITLE
Change 'Members' in UI to 'Children'

### DIFF
--- a/islandora.links.action.yml
+++ b/islandora.links.action.yml
@@ -6,6 +6,6 @@ islandora.add_media_to_node:
 
 islandora.add_member_to_node:
   route_name: islandora.add_member_to_node_page
-  title: Add member
+  title: Add child
   appears_on:
     - view.manage_members.page_1

--- a/modules/islandora_core_feature/config/install/views.view.manage_members.yml
+++ b/modules/islandora_core_feature/config/install/views.view.manage_members.yml
@@ -294,7 +294,7 @@ display:
       path: node/%node/members
       menu:
         type: tab
-        title: Members
+        title: Children
         description: ''
         expanded: false
         parent: ''

--- a/modules/islandora_core_feature/config/install/views.view.members.yml
+++ b/modules/islandora_core_feature/config/install/views.view.members.yml
@@ -225,7 +225,7 @@ display:
       filter_groups:
         operator: AND
         groups: {  }
-      title: Members
+      title: Children
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
**GitHub Issue**: Islandora-CLAW/CLAW/issues/1272

As discussed in [the Islandora 8 Tech Call on September 11, 2019](https://github.com/Islandora-CLAW/CLAW/wiki/September-11%2C-2019).

# What does this Pull Request do?

Simply updates "Members" to "Children" in the front-end UI.

# What's new?

* Changes manage_members view to such that it displays "Children" in the menu tab.
* Changes the "Add members" link on the "Members" (now "Children") tab/page to display "Add child".
* Changes members view to such that it titles the block "Children".
* Does this change require documentation to be updated? _Probably_
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? _Routes cache should be cleared to make the "Add members" button to update._
* Could this change impact execution of existing code? No.

# How should this be tested?

- Setup
    - Make a Parent item.
    - See the "Members" tab displayed.
    - Make some members of the parent item and see the "Members" block display below.
- Apply the PR
- Import the islandora_core_feature (e.g. `drush fim -y islandora_core_feature`)
- Rebuild the caches (e.g. `drush cr`; if that doesn't update the "Add member" link try `drush cc router`)
- Visit the Parent item:
    - The members block should now display "Children" 
    - The "Members" tab should now display "Children"
    - Visiting the "Children" tab should now show the "Add child" button.
- Everything should work as before.

# Additional Notes:

We _could_ take this even further and change all the member references to parents and children in the various machine names... but we are leaving them alone. We should update the docs to be clear about these differences.

# Interested parties
@Islandora-CLAW/committers, esp @dannylamb & @whikloj 
