### PR TITLE
remove field_permissions dependency

### DIFF
--- a/modules/islandora_core_feature/config/install/field.storage.node.field_weight.yml
+++ b/modules/islandora_core_feature/config/install/field.storage.node.field_weight.yml
@@ -2,11 +2,7 @@ langcode: en
 status: true
 dependencies:
   module:
-    - field_permissions
     - node
-third_party_settings:
-  field_permissions:
-    permission_type: public
 id: node.field_weight
 field_name: field_weight
 entity_type: node


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/islandora_defaults/pull/7#issuecomment-533149938

Slack: https://islandora.slack.com/archives/CM5PPAV28/p1568903292154300

# What does this Pull Request do?

Fixes Travis failing on `drush fim -y islandora_core_feature` due to unmet dependency for field_permissions.

# What's new?

* Removed field.storage.node.field_weight.yml dependency on field_permissions
* Does this change require documentation to be updated? No
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? No.

# How should this be tested?

- Merge PR
- Travis is happy again.

# Additional Notes:

None of the other configs in islandora_core_feature require field_permissions; this shouldn't either.

# Interested parties
@dannylamb 
