### PR TITLE
Make fedora uri available on taxonomy terms (issue-1288)

### DIFF
--- a/islandora.module
+++ b/islandora.module
@@ -379,7 +379,7 @@ function islandora_entity_extra_field_info() {
  * Implements hook_entity_view().
  */
 function islandora_entity_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
-  $route_match_item = \Drupal::routeMatch()->getParameters()->all();
+  $route_match_item = \Drupal::routeMatch()->getRawParameters()->all();
   // Ensure the entity matches the route
   if (array_key_exists($entity->getEntityTypeId(), $route_match_item)) {
     if ($display->getComponent('field_gemini_uri')) {

--- a/islandora.module
+++ b/islandora.module
@@ -380,10 +380,8 @@ function islandora_entity_extra_field_info() {
  */
 function islandora_entity_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
   $route_match_item = \Drupal::routeMatch()->getParameters()->all();
-  // Get the parameter, which might be node, media or taxonomy term.
-  $current_entity = reset($route_match_item);
-  // Match exactly to ensure they are the same entity type too.
-  if ($entity === $current_entity) {
+  // Ensure the entity matches the route
+  if (array_key_exists($entity->getEntityTypeId(), $route_match_item)) {
     if ($display->getComponent('field_gemini_uri')) {
       $gemini = \Drupal::service('islandora.gemini.lookup');
       if ($gemini instanceof GeminiLookup) {


### PR DESCRIPTION
**GitHub Issue**: Islandora-CLAW/CLAW/issues/1288

# What does this Pull Request do?

Fixes a route parameter check to work for taxonomy terms and not just nodes and media.

# What's new?

* Changes islandora_entity_view from using getParameters to getRawParameters and update the check to see if the entity type is in the list of parameter keys.
* Does this change require documentation to be updated? No.
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (ie. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? Fixes it.

# How should this be tested?

- Adjust your islandora settings to display the Fedora URI on some taxonomy vocabularies.
- Visit one of them and see no Fedora URI 😞
- Apply the PR
- Clear caches
- Visit the term again and see the Fedora URI 🎉

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
@Islandora-CLAW/committers, esp. @dannylamb and @rosiel 
