### PR TITLE
#1187 Update EVA to 8.x-2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "drupal/jwt": "1.0.0-alpha6",
     "drupal/filehash": "^1.1",
     "drupal/prepopulate" : "^2.2",
-    "drupal/eva" : "^1.3",
+    "drupal/eva" : "^2.0",
     "drupal/features" : "^3.7",
     "drupal/migrate_plus" : "^4.1",
     "drupal/migrate_tools" : "^4.1",


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1187

# What does this Pull Request do?

Update EVA from 8.x-1.3 (unsupported) to 8.x-2.0 (from 5 Nov 2019).

# What's new?
From EVA release notes, "The 2.0 branch is a big refactor of hastily converted Drupal 7 code and includes some fixes and new features. Upgrading from 1.x should be seamless and not require configuration updates."

# How should this be tested?

A description of what steps someone could take to:
* Apply patch
* `composer update drupal/eva`
* Test views depending on EVA, e.g. Repository Items with PDF, OpenSeadragon displays.

# Interested parties
@Islandora-CLAW/committers
